### PR TITLE
update catalog for a single druid

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,10 +53,15 @@ Style/StringLiterals:
 Style/SymbolArray:
   Enabled: false
 
+RSpec/ExampleLength:
+  Max: 50
+
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/controllers/moab_storage_controller_spec.rb'
 
+RSpec/NamedSubject:
+  Enabled: false
 
 Bundler/OrderedGems:
   Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,0 +1,40 @@
+require 'moab/stanford'
+
+##
+# CatalogController allows clients to manipulate the Object Inventory Catalog, e.g.
+# to add an existing moab object to the catalog, or to update an entry for a moab object
+# that's already in the catalog.
+class CatalogController < ApplicationController
+  before_action :set_id
+
+  def add_preserved_object
+    PreservedObject.create!(
+      druid: @id, size: moab_size(@id), current_version: Stanford::StorageServices.current_version(@id)
+    )
+  end
+
+  def update_preserved_object
+    preserved_obj = PreservedObject.find_by(druid: @id)
+    preserved_obj.update_attributes(
+      druid: @id, size: moab_size(@id), current_version: Stanford::StorageServices.current_version(@id)
+    )
+  end
+
+  private
+
+  def set_id
+    @id = catalog_params[:id]
+    head(:unprocessable_entity) if @id.blank?
+  end
+
+  def catalog_params
+    params.permit(:id)
+  end
+
+  def moab_size(id)
+    # TODO: make this actually get the size once there's a method for that.
+    # for now, just using the id to quiet rubocop complaint.
+    # https://github.com/sul-dlss/moab-versioning/issues/21
+    42 || id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
 
   get 'moab_storage/show/:id', to: 'moab_storage#show'
 
+  post 'catalog/add_preserved_object', to: 'catalog#add_preserved_object'
+  post 'catalog/update_preserved_object', to: 'catalog#update_preserved_object'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  describe 'POST #add_preserved_object' do
+    context 'with valid params' do
+      it 'saves the object with the expected field values' do
+        allow(Stanford::StorageServices).to receive(:current_version).and_return(6)
+        allow(subject).to receive(:moab_size).and_return(555)
+        id = 'ab123cd45678'
+
+        allow(PreservedObject).to receive(:create!)
+        post :add_preserved_object, params: { id: id }
+        expect(PreservedObject).to have_received(:create!).with(druid: id, size: 555, current_version: 6)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'returns the unprocessable entity http status code' do
+        post :add_preserved_object
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      it 'updates the object with the expected field values' do
+        allow(Stanford::StorageServices).to receive(:current_version).and_return(6)
+        allow(subject).to receive(:moab_size).and_return(555)
+        id = 'ab123cd45678'
+
+        preserved_obj = instance_double(PreservedObject)
+        allow(PreservedObject).to receive(:find_by).with(druid: id).and_return(preserved_obj)
+
+        allow(preserved_obj).to receive(:update_attributes)
+        put :update_preserved_object, params: { id: id }
+        expect(preserved_obj).to have_received(:update_attributes).with(druid: id, size: 555, current_version: 6)
+      end
+    end
+    context 'with invalid params' do
+      it 'returns the unprocessable entity http status code' do
+        put :update_preserved_object
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* add a CatalogController, which updates the Object Inventory Store (i.e. takes client requests and manipulates the database, based on the contents of moab objects on the file system).
* routes and tests for CatalogController
* change a couple rubocop defaults to allow common departmental practices

this is a first pass at implementing #45.  at the very least, it will require updating `CatalogController#moab_size` to get the actual moab size once sul-dlss/moab-versioning#21 is implemented.  for the purposes of getting a start on this, we've hardcoded a dummy value.

this assumes for now that callers to PCC will either ask to add a record for a moab to the object inventory store, or update an existing record, but that the caller will already know whether the object moab is cataloged in the OIS, and so will not ask for something like "create an entry if one doesn't already exist".  figuring out the particulars of that usage appears to be an open question, at least for us developers right now (see https://github.com/sul-dlss/preservation_core_catalog/issues/45#issuecomment-325750585, https://github.com/sul-dlss/preservation_core_catalog/issues/45#issuecomment-325757624, and https://github.com/sul-dlss/preservation_core_catalog/issues/45#issuecomment-325758392).

does this close out #45, or is there more work to be done in figuring out caller expectations?  if there's more to be done for that ticket, should it go in this PR, or in a follow on PR?

anyway, this
connects to #45

paired w/ @SaravShah on this