### PR TITLE
Moab object size method in show action

### DIFF
--- a/app/controllers/moab_storage_controller.rb
+++ b/app/controllers/moab_storage_controller.rb
@@ -1,4 +1,6 @@
 require 'moab/stanford'
+require 'action_view'
+include ActionView::Helpers::NumberHelper
 
 # API to retrieve data from Moab Object Store
 class MoabStorageController < ApplicationController
@@ -11,7 +13,14 @@ class MoabStorageController < ApplicationController
   end
 
   def show
-    @output = { current_version: Stanford::StorageServices.current_version(params['id']) }
+    moab_path = path_from_object_id(params['id'])
+    object_size = directory_size(moab_path)
+    object_size_human = number_to_human_size(object_size)
+    @output = {
+      current_version: Stanford::StorageServices.current_version(params['id']),
+      object_size: object_size,
+      object_size_human: object_size_human
+    }
     respond_to do |format|
       format.xml { render xml: @output }
       format.all { render json: @output, content_type: 'application/json' }
@@ -27,4 +36,20 @@ class MoabStorageController < ApplicationController
     end
   end
 
+  def path_from_object_id(id)
+    storage_repo = Stanford::StorageRepository.new
+    storage_repo.find_storage_root(id).join(storage_repo.storage_trunk, storage_repo.storage_branch(id)).to_s
+  end
+
+  def directory_size(dirname)
+    size = 0
+    Find.find(dirname) do |path|
+      if FileTest.directory?(path)
+        Find.prune if File.basename(path)[0] == '.'
+      else
+        size += FileTest.size(path)
+      end
+    end
+    size
+  end
 end

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -4,6 +4,9 @@
 # represent a specific stored instance on a specific node, but aggregates
 # those instances.
 class PreservedObject < ApplicationRecord
+  # NOTE: The size field stored in PreservedObject is approximate,as it is determined from size
+  # on disk (which can vary from machine to machine). This field value should not be used for
+  # fixity checking!
   has_many :preservation_copies
   validates :druid, presence: true, uniqueness: true
   validates :current_version, presence: true

--- a/spec/controllers/moab_storage_controller_spec.rb
+++ b/spec/controllers/moab_storage_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe MoabStorageController, type: :controller do
       get :show, params: { id: fixture_druid }
       expect(response).to have_http_status(:success)
     end
+
     context 'assigns @output correctly' do
       it 'Hash' do
         get :show, params: { id: fixture_druid }
@@ -56,6 +57,17 @@ RSpec.describe MoabStorageController, type: :controller do
         get :show, params: { id: fixture_druid }
         expect(assigns(:output)[:current_version]).to eq 10
       end
+
+      it 'object_size' do
+        get :show, params: { id: fixture_druid }
+        expect(assigns(:output)[:object_size]).to be_between(21_900_000, 22_000_000)
+      end
+
+      it 'object_size_human' do
+        get :show, params: { id: fixture_druid }
+        expect(assigns(:output)[:object_size_human]).to a_string_ending_with("MB")
+      end
+
     end
     it 'returns json by default' do
       get :show, params: { id: fixture_druid }


### PR DESCRIPTION
Show action now shows object size of the moab directory. 
Note: Didn't add tests for private methods, since they're pretty simple and are used in public methods.

Note2: Another way to test object_size instead of using `be_between` maybe use the `\du`unix command and use the directory size number from there to compare.

paired w/ @jmartin-sul 