### PR TITLE
Switch db credentials for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,18 @@ and that it's accepting connections:
 
 Use the `psql` utility, which lets you carry out admin functions:
 * Enter `psql postgres` into the command line.
-* Create the preservation core user and grant it the privileges it needs by entering the following commands in psql:
+* Create the preservation core users and grant them the privileges they need for dev and test by entering the following commands in psql:
 ```sql
 CREATE USER preservation_core_catalog;
 ALTER USER preservation_core_catalog CREATEDB;
 CREATE DATABASE preservation_core_catalog;
 ALTER DATABASE preservation_core_catalog OWNER TO preservation_core_catalog;
 GRANT ALL PRIVILEGES ON DATABASE preservation_core_catalog TO preservation_core_catalog;
+CREATE USER pcc;
+ALTER USER pcc CREATEDB;
+CREATE DATABASE pcc;
+ALTER DATABASE pcc OWNER TO pcc;
+GRANT ALL PRIVILEGES ON DATABASE pcc TO pcc;
 ```
 
 For more info on postgres commands, see https://www.postgresql.org/docs/

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,8 +7,8 @@ default: &default
 
 development:
   <<: *default
-  database: preservation_core_catalog
-  username: preservation_core_catalog
+  database: pcc
+  username: pcc
 
 test:
   <<: *default


### PR DESCRIPTION
Fixes #59 

The deploy failed due to discrepancies between `database.yml` and puppet. It's possible to keep `preservation_core_catalog`, and change the username/db in puppet, and I'm open to that, but we can save ssh keystrokes with a shorter username.