### PR TITLE
schema updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -5,4 +5,7 @@ class Endpoint < ApplicationRecord
   has_many :preservation_copies
   validates :endpoint_name, presence: true, uniqueness: true
   validates :endpoint_type, presence: true
+  validates :endpoint_node, presence: true
+  validates :storage_location, presence: true
+  validates :recovery_cost, presence: true
 end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -3,6 +3,8 @@
 # readable name, and the type of endpoint it is (e.g. :online, :archive).
 class Endpoint < ApplicationRecord
   has_many :preservation_copies
+  belongs_to :endpoint_type
+
   validates :endpoint_name, presence: true, uniqueness: true
   validates :endpoint_type, presence: true
   validates :endpoint_node, presence: true

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -4,6 +4,7 @@
 class Endpoint < ApplicationRecord
   has_many :preservation_copies
   belongs_to :endpoint_type
+  has_and_belongs_to_many :preservation_policies
 
   validates :endpoint_name, presence: true, uniqueness: true
   validates :endpoint_type, presence: true

--- a/app/models/endpoint_type.rb
+++ b/app/models/endpoint_type.rb
@@ -1,0 +1,8 @@
+##
+# metadata about a specific replication endpoint
+class EndpointType < ApplicationRecord
+  has_many :endpoints
+
+  validates :type_name, presence: true, uniqueness: true
+  validates :endpoint_class, presence: true
+end

--- a/app/models/preservation_copy.rb
+++ b/app/models/preservation_copy.rb
@@ -3,7 +3,10 @@
 class PreservationCopy < ApplicationRecord
   belongs_to :preserved_object
   belongs_to :endpoint
+  belongs_to :status
+
   validates :preserved_object, presence: true
   validates :endpoint, presence: true
   validates :current_version, presence: true
+  validates :status, presence: true
 end

--- a/app/models/preservation_policy.rb
+++ b/app/models/preservation_policy.rb
@@ -1,0 +1,7 @@
+##
+# defines some characteristics about how an object should be preserved, or how an endpoint preserves objects
+class PreservationPolicy < ApplicationRecord
+  has_and_belongs_to_many :endpoints
+
+  validates :preservation_policy_name, presence: true
+end

--- a/app/models/preservation_policy.rb
+++ b/app/models/preservation_policy.rb
@@ -1,6 +1,7 @@
 ##
 # defines some characteristics about how an object should be preserved, or how an endpoint preserves objects
 class PreservationPolicy < ApplicationRecord
+  has_many :preserved_objects
   has_and_belongs_to_many :endpoints
 
   validates :preservation_policy_name, presence: true

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -7,7 +7,9 @@ class PreservedObject < ApplicationRecord
   # NOTE: The size field stored in PreservedObject is approximate,as it is determined from size
   # on disk (which can vary from machine to machine). This field value should not be used for
   # fixity checking!
+  belongs_to :preservation_policy
   has_many :preservation_copies
   validates :druid, presence: true, uniqueness: true
   validates :current_version, presence: true
+  validates :preservation_policy, null: false
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,6 @@
+##
+# the current status of a preservation copy, e.g. all good, fixity check failed, etc
+class Status < ApplicationRecord
+  has_many :preservation_copies
+  validates :status_text, presence: true
+end

--- a/db/migrate/20170907215045_add_details_to_endpoints.rb
+++ b/db/migrate/20170907215045_add_details_to_endpoints.rb
@@ -1,0 +1,8 @@
+class AddDetailsToEndpoints < ActiveRecord::Migration[5.1]
+  def change
+    add_column :endpoints, :endpoint_node, :string, null: false
+    add_column :endpoints, :storage_location, :string, null: false
+    add_column :endpoints, :recovery_cost, :int, null: false
+    add_column :endpoints, :access_key, :string
+  end
+end

--- a/db/migrate/20170907215505_remove_status_from_preservation_copies.rb
+++ b/db/migrate/20170907215505_remove_status_from_preservation_copies.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromPreservationCopies < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :preservation_copies, :status, :string
+  end
+end

--- a/db/migrate/20170907215849_create_statuses.rb
+++ b/db/migrate/20170907215849_create_statuses.rb
@@ -1,0 +1,7 @@
+class CreateStatuses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :statuses do |t|
+      t.string :status_text, null: false
+    end
+  end
+end

--- a/db/migrate/20170907234425_add_status_to_preservation_copies.rb
+++ b/db/migrate/20170907234425_add_status_to_preservation_copies.rb
@@ -1,0 +1,5 @@
+class AddStatusToPreservationCopies < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :preservation_copies, :status, foreign_key: true, null: false
+  end
+end

--- a/db/migrate/20170908000116_create_endpoint_types.rb
+++ b/db/migrate/20170908000116_create_endpoint_types.rb
@@ -1,0 +1,10 @@
+class CreateEndpointTypes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :endpoint_types do |t|
+      t.string :type_name, null: false, unique: true
+      t.string :endpoint_class, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170908000316_remove_endpoint_type_from_endpoint.rb
+++ b/db/migrate/20170908000316_remove_endpoint_type_from_endpoint.rb
@@ -1,0 +1,5 @@
+class RemoveEndpointTypeFromEndpoint < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :endpoints, :endpoint_type, :string
+  end
+end

--- a/db/migrate/20170908000340_add_endpoint_type_to_endpoint.rb
+++ b/db/migrate/20170908000340_add_endpoint_type_to_endpoint.rb
@@ -1,0 +1,5 @@
+class AddEndpointTypeToEndpoint < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :endpoints, :endpoint_type, foreign_key: true, null: false
+  end
+end

--- a/db/migrate/20170908203419_create_preservation_policies.rb
+++ b/db/migrate/20170908203419_create_preservation_policies.rb
@@ -1,0 +1,7 @@
+class CreatePreservationPolicies < ActiveRecord::Migration[5.1]
+  def change
+    create_table :preservation_policies do |t|
+      t.string :preservation_policy_name, null: false
+    end
+  end
+end

--- a/db/migrate/20170908204701_create_endpoints_preservation_policies.rb
+++ b/db/migrate/20170908204701_create_endpoints_preservation_policies.rb
@@ -1,0 +1,8 @@
+class CreateEndpointsPreservationPolicies < ActiveRecord::Migration[5.1]
+  def change
+    create_table :endpoints_preservation_policies do |t|
+      t.references :preservation_policy, foreign_key: true, null: false
+      t.references :endpoint, foreign_key: true, null: false
+    end
+  end
+end

--- a/db/migrate/20170908214803_remove_preservation_policy_from_preserved_objects.rb
+++ b/db/migrate/20170908214803_remove_preservation_policy_from_preserved_objects.rb
@@ -1,0 +1,5 @@
+class RemovePreservationPolicyFromPreservedObjects < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :preserved_objects, :preservation_policy, :string
+  end
+end

--- a/db/migrate/20170908214835_add_preservation_policy_to_preserved_object.rb
+++ b/db/migrate/20170908214835_add_preservation_policy_to_preserved_object.rb
@@ -1,0 +1,5 @@
+class AddPreservationPolicyToPreservedObject < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :preserved_objects, :preservation_policy, foreign_key: true, index: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,44 +10,76 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823233217) do
+ActiveRecord::Schema.define(version: 20170908214835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "endpoints", force: :cascade do |t|
-    t.string "endpoint_name", null: false
-    t.string "endpoint_type", null: false
+  create_table "endpoint_types", force: :cascade do |t|
+    t.string "type_name", null: false
+    t.string "endpoint_class", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "endpoints", force: :cascade do |t|
+    t.string "endpoint_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "endpoint_node", null: false
+    t.string "storage_location", null: false
+    t.integer "recovery_cost", null: false
+    t.string "access_key"
+    t.bigint "endpoint_type_id", null: false
     t.index ["endpoint_name"], name: "index_endpoints_on_endpoint_name"
-    t.index ["endpoint_type"], name: "index_endpoints_on_endpoint_type"
+    t.index ["endpoint_type_id"], name: "index_endpoints_on_endpoint_type_id"
+  end
+
+  create_table "endpoints_preservation_policies", force: :cascade do |t|
+    t.bigint "preservation_policy_id", null: false
+    t.bigint "endpoint_id", null: false
+    t.index ["endpoint_id"], name: "index_endpoints_preservation_policies_on_endpoint_id"
+    t.index ["preservation_policy_id"], name: "index_endpoints_preservation_policies_on_preservation_policy_id"
   end
 
   create_table "preservation_copies", force: :cascade do |t|
     t.integer "current_version", null: false
-    t.string "status"
     t.bigint "last_audited"
     t.bigint "preserved_object_id", null: false
     t.bigint "endpoint_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "status_id", null: false
     t.index ["endpoint_id"], name: "index_preservation_copies_on_endpoint_id"
     t.index ["last_audited"], name: "index_preservation_copies_on_last_audited"
     t.index ["preserved_object_id"], name: "index_preservation_copies_on_preserved_object_id"
+    t.index ["status_id"], name: "index_preservation_copies_on_status_id"
+  end
+
+  create_table "preservation_policies", force: :cascade do |t|
+    t.string "preservation_policy_name", null: false
   end
 
   create_table "preserved_objects", force: :cascade do |t|
     t.string "druid", null: false
     t.integer "current_version", null: false
-    t.string "preservation_policy"
     t.integer "size"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "preservation_policy_id", null: false
     t.index ["druid"], name: "index_preserved_objects_on_druid"
-    t.index ["preservation_policy"], name: "index_preserved_objects_on_preservation_policy"
+    t.index ["preservation_policy_id"], name: "index_preserved_objects_on_preservation_policy_id"
   end
 
+  create_table "statuses", force: :cascade do |t|
+    t.string "status_text", null: false
+  end
+
+  add_foreign_key "endpoints", "endpoint_types"
+  add_foreign_key "endpoints_preservation_policies", "endpoints"
+  add_foreign_key "endpoints_preservation_policies", "preservation_policies"
   add_foreign_key "preservation_copies", "endpoints"
   add_foreign_key "preservation_copies", "preserved_objects"
+  add_foreign_key "preservation_copies", "statuses"
+  add_foreign_key "preserved_objects", "preservation_policies"
 end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -2,7 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Endpoint, type: :model do
 
-  let!(:endpoint) { Endpoint.create(endpoint_name: 'aws', endpoint_type: 'cloud') }
+  let!(:endpoint_type) { EndpointType.create(type_name: 'aws', endpoint_class: 'archive') }
+  let!(:endpoint) do
+    Endpoint.create(
+      endpoint_name: 'aws',
+      endpoint_type_id: endpoint_type.id,
+      endpoint_node: 'sul-sdr',
+      storage_location: '/storage',
+      recovery_cost: '1'
+    )
+  end
 
   it 'is not valid without valid attributes' do
     expect(Endpoint.new).not_to be_valid
@@ -18,11 +27,19 @@ RSpec.describe Endpoint, type: :model do
 
   it 'enforces unique constraint on endpoint_name' do
     expect do
-      Endpoint.create!(endpoint_name: 'aws', endpoint_type: 'cloud')
+      Endpoint.create!(
+        endpoint_name: 'aws',
+        endpoint_type_id: endpoint_type.id,
+        endpoint_node: 'sul-sdr',
+        storage_location: '/storage',
+        recovery_cost: '1'
+      )
     end.to raise_error(ActiveRecord::RecordInvalid)
   end
 
   it { is_expected.to have_many(:preservation_copies) }
   it { is_expected.to have_db_index(:endpoint_name) }
-  it { is_expected.to have_db_index(:endpoint_type) }
+  it { is_expected.to have_db_index(:endpoint_type_id) }
+  it { is_expected.to have_and_belong_to_many(:preservation_policies) }
+  it { is_expected.to belong_to(:endpoint_type) }
 end

--- a/spec/models/endpoint_type_spec.rb
+++ b/spec/models/endpoint_type_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe EndpointType, type: :model do
+  let!(:endpoint_type) { EndpointType.create!(type_name: 'nfs', endpoint_class: 'online') }
+
+  it 'is valid with valid attributes' do
+    expect(endpoint_type).to be_valid
+  end
+
+  it 'is not valid without valid attributes' do
+    expect(EndpointType.new).not_to be_valid
+  end
+
+  it 'enforces unique constraint on type_name' do
+    expect do
+      EndpointType.create!(type_name: 'nfs', endpoint_class: 'online')
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it { is_expected.to have_many(:endpoints) }
+end

--- a/spec/models/preservation_copy_spec.rb
+++ b/spec/models/preservation_copy_spec.rb
@@ -1,16 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe PreservationCopy, type: :model do
-  let!(:preservation_object2) do
-    PreservedObject.create!(druid: 'ab123cd45679', current_version: 1, preservation_policy: 'keepit', size: 1)
+  let!(:endpoint_type) { EndpointType.create(type_name: 'aws', endpoint_class: 'archive') }
+  let!(:endpoint) do
+    Endpoint.create(
+      endpoint_name: 'aws',
+      endpoint_type_id: endpoint_type.id,
+      endpoint_node: 'sul-sdr',
+      storage_location: '/storage',
+      recovery_cost: '1'
+    )
   end
-  let!(:endpoint2) { Endpoint.create!(endpoint_name: 'oracle', endpoint_type: 'cloud') }
+  let!(:preservation_policy) { PreservationPolicy.create!(preservation_policy_name: 'default') }
+
+  let!(:preserved_object) do
+    PreservedObject.create!(
+      druid: 'ab123cd45679', current_version: 1, preservation_policy_id: preservation_policy.id, size: 1
+    )
+  end
+  let!(:status) { Status.create!(status_text: 'ok') }
   let!(:preservation_copy) do
     PreservationCopy.create!(
-      preserved_object_id: preservation_object2.id,
-      endpoint_id: endpoint2.id,
+      preserved_object_id: preserved_object.id,
+      endpoint_id: endpoint.id,
       current_version: 0,
-      status: 'fixity_error'
+      status_id: status.id
     )
   end
 
@@ -19,7 +33,7 @@ RSpec.describe PreservationCopy, type: :model do
   end
 
   it 'is not valid unless it has all required attributes' do
-    expect(PreservationCopy.new(preserved_object_id: preservation_object2.id)).not_to be_valid
+    expect(PreservationCopy.new(preserved_object_id: preserved_object.id)).not_to be_valid
   end
 
   it 'is valid with valid attributes' do
@@ -28,6 +42,7 @@ RSpec.describe PreservationCopy, type: :model do
 
   it { is_expected.to belong_to(:endpoint) }
   it { is_expected.to belong_to(:preserved_object) }
+  it { is_expected.to belong_to(:status) }
   it { is_expected.to have_db_index(:last_audited) }
   it { is_expected.to have_db_index(:endpoint_id) }
   it { is_expected.to have_db_index(:preserved_object_id) }

--- a/spec/models/preservation_policy_spec.rb
+++ b/spec/models/preservation_policy_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PreservationPolicy, type: :model do
+  let!(:preservation_policy) { PreservationPolicy.create!(preservation_policy_name: 'default') }
+
+  it 'is valid with valid attributes' do
+    expect(preservation_policy).to be_valid
+  end
+
+  it 'is not valid without valid attributes' do
+    expect(PreservationPolicy.new).not_to be_valid
+  end
+
+  it { is_expected.to have_many(:preserved_objects) }
+  it { is_expected.to have_and_belong_to_many(:endpoints) }
+end

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -1,22 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe PreservedObject, type: :model do
+  let!(:preservation_policy) { PreservationPolicy.create!(preservation_policy_name: 'default') }
+
   let(:required_attributes) do
     {
       druid: 'ab123cd45678',
-      current_version: 1
+      current_version: 1,
+      preservation_policy: preservation_policy
     }
   end
   let(:addl_attributes) do
     {
-      preservation_policy: 'keepit',
       size: 1
     }
   end
 
+  it { is_expected.to belong_to(:preservation_policy) }
   it { is_expected.to have_many(:preservation_copies) }
   it { is_expected.to have_db_index(:druid) }
-  it { is_expected.to have_db_index(:preservation_policy) }
+  it { is_expected.to have_db_index(:preservation_policy_id) }
 
   context 'validation' do
     it 'is valid with required attributes' do
@@ -39,8 +42,9 @@ RSpec.describe PreservedObject, type: :model do
     it 'enforces unique constraint on druid' do
       PreservedObject.create(required_attributes)
       exp_err_msg = 'Validation failed: Druid has already been taken'
-      expect { PreservedObject.create!(required_attributes) }.to raise_error(ActiveRecord::RecordInvalid, exp_err_msg)
+      expect do
+        PreservedObject.create!(required_attributes)
+      end.to raise_error(ActiveRecord::RecordInvalid, exp_err_msg)
     end
   end
-
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Status, type: :model do
+  let!(:status) { Status.create!(status_text: 'ok') }
+
+  it 'is valid with valid attributes' do
+    expect(status).to be_valid
+  end
+
+  it 'is not valid without valid attributes' do
+    expect(Status.new).not_to be_valid
+  end
+
+  it { is_expected.to have_many(:preservation_copies) }
+end


### PR DESCRIPTION
this is an attempt to implement the schema improvements outlined in #46.  paired w/ @SaravShah on the implementation.

i'd initially figured i'd squash everything into one commit, but i was actually able to separate things out into somewhat logical groupings of changes that built on one another.  unfortunately, we were a bit messy about committing our WIP, and we did all the test updates after the implementation.  so while i'd ideally like each commit to be a working build, that's unlikely to be the case, since some of the test fixes were clumped together.  the different chunks of the schema migration and their accompanying model changes are pretty well grouped, though, hopefully.  happy to do more commit squashing or splitting if people have suggestions, and will try to be better about keeping tests in sync as work goes on future PRs like this.

re: the rubocop exception, i'm guessing rubocop's thinking is something along the lines of:  http://blog.flatironschool.com/why-you-dont-need-has-and-belongs-to-many/

but @SaravShah and i both felt like that was overkill in this case.  the join table is there, and if we need to add more columns to it, a migration and a model of its own (and the implied AR association and test updates) shouldn't be hard to add.  and the rails guide seems to suggest `has_and_belongs_to_many` for this use case:
http://guides.rubyonrails.org/association_basics.html#the-has-and-belongs-to-many-association
http://guides.rubyonrails.org/association_basics.html#the-has-many-through-association

@julianmorley, i realized friday afternoon when i was looking over these changes to see if we missed anything, that we had indeed missed getting rid of creation dates.  i swear we didn't do that on purpose, though i admit i was reticent to drop the column when we met about the schema changes week before last 😈 .  umm... would you mind if we file a ticket to get rid of it if we find that the column really does lead to space usage and/or performance issues?  it looks pretty easy to get rid of by using [`remove_timestamps`](http://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method).  but one nice thing is that active record magic manages creation and update timestamps on rows if the columns are there, and i'm not sure if having only one of the columns there would then also necessitate manually managing those timestamps.

i tried to follow the direction of @ndushay's refactoring when resolving the conflict that came up in `preserved_object_spec.rb` when rebasing, but didn't bother going and doing similar refactoring on the other specs (extant or added).  i'd propose saving that for a follow-on ticket/PR.

closes #46