### PR TITLE
add postgres to rake commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ and that it's accepting connections:
 
 Using the `psql` utility, run these two setup scripts from the command line, like so:
 ```sh
-psql -f db/scripts/pcc_setup.sql
-psql -f db/scripts/preservation_core_catalog_setup.sql
+psql -f db/scripts/pcc_setup.sql postgres
+psql -f db/scripts/preservation_core_catalog_setup.sql postgres
 ```
 
 These scripts do the following for you:


### PR DESCRIPTION
Adding ```postgres``` to ```psql -f db/scripts/pcc_setup.sql postgres``` and ```psql -f db/scripts/preservation_core_catalog_setup.sql postgres```
