### PR TITLE
README.md: replace boilerplate text somewhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,7 @@
 Rails application with fixity data and object provenance supporting preservation object storage audit services
 
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## Configuration
 
 ### Setting up PostgreSQL
 
@@ -62,3 +41,22 @@ These scripts do the following for you:
 * setup the needed ownership and permissions between the DBs and the users.
 
 For more info on postgres commands, see https://www.postgresql.org/docs/
+
+
+## Usage Instructions
+
+TODO: write these
+
+## Development
+
+### Running Tests
+
+To run the tests:
+
+```sh
+rake spec
+```
+
+## Deploying
+
+Capistrano is used to deploy.


### PR DESCRIPTION
Just noticed we had the rails boilerplate text and it was time for it to go away.