### PR TITLE
Update Gemfile.lock with working shoulda-matchers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: edaf9cb926ee9c59c59729e7a4f8c206b44da8a1
+  revision: 4b160bd19ecca7f97d7ac22dccd5fde9b0da5a9f
   branch: rails-5
   specs:
     shoulda-matchers (3.1.2)
@@ -55,7 +55,7 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.1.0)
-    capistrano (3.9.0)
+    capistrano (3.9.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -74,7 +74,7 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    coderay (1.1.1)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     config (1.4.0)
       activesupport (>= 3.0)
@@ -117,7 +117,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     moab-versioning (2.1.0)
       confstruct
@@ -125,24 +125,23 @@ GEM
       nokogiri
       nokogiri-happymapper
       systemu
-    multi_json (1.12.1)
+    multi_json (1.12.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (4.1.0)
+    net-ssh (4.2.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
-    nokogiri-happymapper (0.5.9)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    nokogiri-happymapper (0.6.0)
       nokogiri (~> 1.5)
     parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
     powerpack (0.1.1)
-    pry (0.10.4)
+    pry (0.11.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
-      slop (~> 3.4)
     pry-byebug (3.5.0)
       byebug (~> 9.1)
       pry (~> 0.10)
@@ -209,16 +208,15 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.15.1)
-      rubocop (>= 0.42.0)
-    ruby-progressbar (1.8.1)
+    rubocop-rspec (1.16.0)
+      rubocop (>= 0.49.0)
+    ruby-progressbar (1.8.3)
     ruby_dep (1.5.0)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -274,4 +272,4 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.15.4


### PR DESCRIPTION
The shoulda-matchers gem we're using was not working for me because I think Gemfile.lock was pointing to a commit that is problematic. This PR hopefully fixes the problem.

As a side-effect, I hope this will get rid of the warning:

"The latest bundler is 1.16.0.pre.2, but you are currently running 1.15.4.
To update, run gem install bundler --pre"

as this also changes our bundler version to be a regular release rather than a pre-release. There are also some fairly minor updates of other gems that I hope will be OK.