### PR TITLE
enumerate moabs in directory

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,3 @@
-require 'moab/stanford'
-
 ##
 # CatalogController allows clients to manipulate the Object Inventory Catalog, e.g.
 # to add an existing moab object to the catalog, or to update an entry for a moab object

--- a/app/controllers/moab_storage_controller.rb
+++ b/app/controllers/moab_storage_controller.rb
@@ -1,4 +1,3 @@
-require 'moab/stanford'
 require 'action_view'
 include ActionView::Helpers::NumberHelper
 

--- a/app/models/moab_storage_directory.rb
+++ b/app/models/moab_storage_directory.rb
@@ -1,0 +1,35 @@
+##
+# methods for dealing with a directory which stores Moab objects
+class MoabStorageDirectory
+  # TODO: if this ends up getting pushed up into moab-versioning, which already has at least
+  # one instance of the druid regex (in storage_repository.rb), consolidate and reference a single
+  # constant after the move.
+  DRUID_TREE_REGEXP = '[[:lower:]]{2}/\\d{3}/[[:lower:]]{2}/\\d{4}'.freeze
+  DRUID_REGEXP = '[[:lower:]]{2}\\d{3}[[:lower:]]{2}\\d{4}'.freeze
+
+  def self.find_moab_paths(storage_dir)
+    Find.find(storage_dir) do |path|
+      Find.prune unless File.directory?(path) # don't bother with a matching on files, we only care about directories
+      path_match_data = storage_dir_regexp(storage_dir).match(path)
+      if path_match_data
+        yield path_match_data[1], path, path_match_data # yield the druid, the full path, and the MatchData object
+        Find.prune # we don't care about what's in the moab dir, we just want the paths that look like moabs
+      end
+    end
+  end
+
+  def self.list_moab_druids(storage_dir)
+    druids = []
+    find_moab_paths(storage_dir) { |druid, _path, _path_match_data| druids << druid }
+    druids
+  end
+
+  private_class_method def self.storage_dir_regexps
+    @storage_dir_regexps ||= {}
+  end
+
+  # this regexp caching makes things many times faster (e.g. went from ~2200 s to crawl disk11, down to ~300 s)
+  private_class_method def self.storage_dir_regexp(storage_dir)
+    storage_dir_regexps[storage_dir] ||= Regexp.new("^#{storage_dir}/#{DRUID_TREE_REGEXP}/(#{DRUID_REGEXP})$")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,9 +19,3 @@ module PreservationCoreCatalog
     # -- all .rb files in that directory are automatically loaded.
   end
 end
-
-require 'moab'
-Moab::Config.configure do
-  storage_roots File.join(File.dirname(__FILE__), '..', Settings.moab.storage_roots)
-  storage_trunk Settings.moab.storage_trunk
-end

--- a/config/initializers/moab_config.rb
+++ b/config/initializers/moab_config.rb
@@ -1,0 +1,7 @@
+require 'moab'
+require 'moab/stanford'
+
+Moab::Config.configure do
+  storage_roots Settings.moab.storage_roots
+  storage_trunk Settings.moab.storage_trunk
+end

--- a/lib/benchmarking/checksum_testing.rb
+++ b/lib/benchmarking/checksum_testing.rb
@@ -29,7 +29,7 @@ require 'pathname'
 # 214G test file
 # '/services-disk11/sdr2objects/fj/491/sg/9116/fj491sg9116/v0001/data/content/fj491sg9116_pm.mov'
 
-logger = Logger.new('log/checksum_benchmark.log')
+logger = Logger.new('log/benchmark_checksum.log')
 pcc_app_home = '/opt/app/pcc/preservation_core_catalog'
 revisions_log = "#{pcc_app_home}/revisions.log"
 buffer_size = ARGV[0].to_i

--- a/lib/benchmarking/moab_enumeration_testing.rb
+++ b/lib/benchmarking/moab_enumeration_testing.rb
@@ -1,0 +1,110 @@
+# rails runner moab_enumeration_testing.rb
+require 'benchmark'
+require 'logger'
+
+##
+# simple class for collecting stats on how fast different moab listing methods run.
+#
+# Usage:
+# $ bundle exec rails console # from shell prompt
+# > require './lib/benchmarking/moab_enumeration_testing.rb'
+# > benchmarker = MoabEnumerationBenchmarker.new
+# > benchmarker.benchmark
+class MoabEnumerationBenchmarker
+  attr_accessor :storage_dirs, :all_results, :methods_to_test
+
+  def benchmarked_revision
+    pcc_app_home = '/opt/app/pcc/preservation_core_catalog'
+    revisions_log = "#{pcc_app_home}/revisions.log"
+
+    # last line of revisions.log if it exists
+    # or else grab current revision
+    if File.file?(revisions_log)
+      File.readlines(revisions_log).last
+    else
+      commit = `git rev-parse HEAD`
+      "at revision #{commit}"
+    end
+  end
+
+  def logger
+    @logger ||= Logger.new('log/benchmark.log')
+  end
+
+  def all_results
+    @all_results ||= []
+  end
+
+  def methods_to_test
+    @methods_to_test ||= [:list_moab_druids]
+  end
+
+  def storage_dirs
+    @storage_dirs ||= Stanford::StorageServices.storage_roots.map do |strg_rt|
+      File.join(strg_rt, Moab::Config.storage_trunk)
+    end
+  end
+
+  def benchmark
+    logger.info "MoabEnumerationBenchmarker.benchmark is running at #{Time.now.getlocal}"
+    logger.info benchmarked_revision
+
+    methods_to_test.each { |method_name| collect_results_for_method(method_name) }
+
+    logger.info "Benchmarking stopped at #{Time.now.getlocal}"
+  end
+
+  # defaults to not listing out all the druids, because on real storage disks, that'll
+  # be *lots*, and we probably want to use this for printing
+  def to_json(redact_druids = true)
+    all_results.map do |result|
+      {
+        method_name: result[:method_name],
+        storage_dir: result[:storage_dir],
+        druid_count: redact_druids ? result[:druid_list].length : result[:druid_list],
+        elapsed_time: result[:elapsed_time],
+        druids_per_second: result[:druids_per_second],
+        benchmark: result[:benchmark]
+      }
+    end
+  end
+
+  def to_s(redact_druids = true)
+    JSON.pretty_generate(to_json(redact_druids))
+  end
+
+  def dump_all_results
+    log_and_print to_s
+  end
+
+  private
+
+  # this class was initially used for manual benchmarking, where writing a quick msg to stdout is helpful
+  # rubocop:disable Rails/Output
+  def log_and_print(msg)
+    logger.info msg
+    puts "#{msg}\n"
+  end
+  # rubocop:enable Rails/Output
+
+  def collect_results_for_method(method_name)
+    storage_dirs.each do |storage_dir|
+      dir_result = collect_stats_for_dir(method_name, storage_dir)
+      all_results << dir_result
+      log_and_print "#{storage_dir}: #{method_name} found "\
+        "#{dir_result[:druid_list].length} druids in #{dir_result[:elapsed_time]} s "\
+        "(#{dir_result[:druids_per_second]} druids/s)"
+    end
+  end
+
+  def collect_stats_for_dir(method_name, storage_dir)
+    dir_result = { method_name: method_name, storage_dir: storage_dir }
+    dir_result[:benchmark] = Benchmark.bm(storage_dir.length + 5) do |x|
+      dir_result[:elapsed_time] = x.report("#{method_name}:\n  #{storage_dir}:") do
+        dir_result[:druid_list] = MoabStorageDirectory.send(method_name, storage_dir)
+      end.real
+    end
+    dir_result[:druids_per_second] = dir_result[:druid_list].length / dir_result[:elapsed_time]
+    dir_result
+  end
+end

--- a/lib/benchmarking/moab_enumeration_testing.rb
+++ b/lib/benchmarking/moab_enumeration_testing.rb
@@ -28,7 +28,7 @@ class MoabEnumerationBenchmarker
   end
 
   def logger
-    @logger ||= Logger.new('log/benchmark.log')
+    @logger ||= Logger.new('log/benchmark_moab_enumeration.log')
   end
 
   def all_results

--- a/lib/benchmarking/postgres_testing.rb
+++ b/lib/benchmarking/postgres_testing.rb
@@ -1,7 +1,7 @@
 # rails runner postgres_testing.rb
 require 'benchmark'
 require 'logger'
-logger = Logger.new('log/postgres_benchmark.log')
+logger = Logger.new('log/benchmark_postgres.log')
 
 at_exit do
   logger.info "Benchmarking stopped at #{Time.now.getlocal}"

--- a/spec/models/moab_storage_directory_spec.rb
+++ b/spec/models/moab_storage_directory_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe MoabStorageDirectory, type: :model do
+  let(:storage_dir) { 'spec/fixtures/moab_storage_root' }
+
+  describe '.find_moab_paths' do
+    it 'passes a druid as the first parameter to the block it gets' do
+      MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, _path, _path_match_data|
+        expect(druid).to match(/[[:lower:]]{2}\d{3}[[:lower:]]{2}\d{4}/)
+      end
+    end
+    it 'passes a valid file path as the second parameter to the block it gets' do
+      MoabStorageDirectory.find_moab_paths(storage_dir) do |_druid, path, _path_match_data|
+        expect(File.exist?(path)).to be true
+      end
+    end
+    it 'passes a MatchData object as the third parameter to the block it gets' do
+      MoabStorageDirectory.find_moab_paths(storage_dir) do |_druid, _path, path_match_data|
+        expect(path_match_data).to be_a_kind_of(MatchData)
+      end
+    end
+  end
+
+  describe '.list_moab_druids' do
+    let(:druids) { MoabStorageDirectory.list_moab_druids(storage_dir) }
+
+    it 'lists the expected druids in the fixture directory' do
+      expect(druids).to include('bj102hs9687', 'bp628nk4868', 'bz514sm9647', 'dc048cw1328', 'jj925bx9565')
+    end
+    it 'returns only the expected druids in the fixture directory' do
+      expect(druids.length).to eq 5
+    end
+  end
+
+  describe '.storage_dir_regexp' do
+    it 'caches the regular expression used to match druid paths under a given directory' do
+      allow(Regexp).to receive(:new).and_call_original
+      MoabStorageDirectory.send(:storage_dir_regexp, 'foo')
+      MoabStorageDirectory.send(:storage_dir_regexp, 'foo')
+      expect(Regexp).to have_received(:new).once
+    end
+  end
+end


### PR DESCRIPTION
the `MoabStorageDirectory` class offers a couple of methods that allow storage root traversal and listing.  each takes a directory that contains a druid tree (such as a storage trunk in a storage root).

`.find_moab_paths` will allow the caller to pass in a block, which will then get the `druid`, `path`, and `MatchData` object as parameters for each druid under the specified directory.  `.list_moab_druids` provides a convenient wrapper around this method, and just returns a list of all druids in the given directory.

closes #67