### PR TITLE
Add timestamps to preservation_copies for checking db, storage roots …

### DIFF
--- a/db/migrate/20170925210519_add_last_checked_on_storage_and_last_checksum_validation_to_preservation_copies.rb
+++ b/db/migrate/20170925210519_add_last_checked_on_storage_and_last_checksum_validation_to_preservation_copies.rb
@@ -1,0 +1,6 @@
+class AddLastCheckedOnStorageAndLastChecksumValidationToPreservationCopies < ActiveRecord::Migration[5.1]
+  def change
+    add_column :preservation_copies, :last_checked_on_storage, :datetime
+    add_column :preservation_copies, :last_checksum_validation, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170908214835) do
+ActiveRecord::Schema.define(version: 20170925210519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 20170908214835) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "status_id", null: false
+    t.datetime "last_checked_on_storage"
+    t.datetime "last_checksum_validation"
     t.index ["endpoint_id"], name: "index_preservation_copies_on_endpoint_id"
     t.index ["last_audited"], name: "index_preservation_copies_on_last_audited"
     t.index ["preserved_object_id"], name: "index_preservation_copies_on_preserved_object_id"


### PR DESCRIPTION
…and checksum validations

  Open to shortening the migration name to fewer than 90 characters...

  Closes #106