### PR TITLE
PreservedObjectHandler service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ config/environments/*.local.yml
 
 .ruby-gemset
 .ruby-version
+
+**/.DS_Store

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,15 +37,32 @@ Layout/EmptyLinesAroundClassBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
 # --- Metrics ---
+
+Metrics/AbcSize:
+  Exclude:
+    - 'app/services/preserved_object_handler.rb' # 2 methods but they seem readable
 
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ClassLength:
+  Max: 120
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/services/preserved_object_handler.rb' # a method that is simply a case statement
+
 # because this isn't 1994
 Metrics/LineLength:
   Max: 120
+  Exclude:
+    - 'app/services/preserved_object_handler.rb' # 2 lines 121
+    - 'spec/services/preserved_object_handler_spec.rb' # 3 lines are longer
 
 Metrics/MethodLength:
   Max: 20
@@ -57,7 +74,7 @@ Rails/HasAndBelongsToMany:
 
 Rails/SkipsModelValidations:
   Exclude:
-    - 'app/services/preserved_object_handler.rb' # because we're using touch on purpose
+    - 'app/services/preserved_object_handler.rb' # we're using touch on purpose
 
 # --- RSpec ---
 
@@ -67,11 +84,16 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Max: 2
 
+Rspec/MessageSpies:
+  Exclude:
+    - 'spec/services/preserved_object_handler_spec.rb' # couldn't figure out a logging test
+
 RSpec/NamedSubject:
   Enabled: false
 
 RSpec/NestedGroups:
-  Max: 4
+  Exclude:
+    - 'spec/services/preserved_object_handler_spec.rb'
 
 # --- Style ---
 
@@ -79,6 +101,13 @@ Style/FileName:
   Exclude:
     - 'Capfile'
     - 'Gemfile'
+
+Style/FormatString:
+  Exclude:
+    - 'app/services/preserved_object_handler.rb' # using interpolated strings
+
+Style/FormatStringToken:
+  EnforcedStyle: template # using interpolated strings in PreservedObjectHandler
 
 # because ' vs " isn't a big deal for readability or maintainability or execution time
 Style/StringLiterals:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
+# --- Layout ---
 
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
@@ -36,6 +37,7 @@ Layout/EmptyLinesAroundClassBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
+# --- Metrics ---
 
 Metrics/BlockLength:
   Exclude:
@@ -48,43 +50,37 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 20
 
+# --- Rails ---
 
 Rails/HasAndBelongsToMany:
   Enabled: false
 
 Rails/SkipsModelValidations:
   Exclude:
-    - 'app/models/preserved_object.rb' # because we're using touch on purpose
+    - 'app/services/preserved_object_handler.rb' # because we're using touch on purpose
 
-
-RSpec/BeforeAfterAll:
-  Exclude:
-    - 'spec/models/preserved_object_spec.rb' # after(:all) is fine here
+# --- RSpec ---
 
 RSpec/ExampleLength:
   Max: 50
 
-RSpec/MessageSpies:
-  Exclude:
-    - 'spec/models/preserved_object_spec.rb' # have_received is a pain here
-
 RSpec/MultipleExpectations:
-  Exclude:
-    - 'spec/controllers/moab_storage_controller_spec.rb'
-    - 'spec/models/preserved_object_spec.rb'
-
-RSpec/NestedGroups:
-  Max: 4
+  Max: 2
 
 RSpec/NamedSubject:
   Enabled: false
 
+RSpec/NestedGroups:
+  Max: 4
+
+# --- Style ---
 
 Style/FileName:
   Exclude:
     - 'Capfile'
     - 'Gemfile'
 
+# because ' vs " isn't a big deal for readability or maintainability or execution time
 Style/StringLiterals:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,8 +22,20 @@ AllCops:
 Rails:
   Enabled: true
 
-Rails/HasAndBelongsToMany:
+Bundler/OrderedGems:
+  Exclude:
+    - 'Gemfile'
+
+
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
 
 Metrics/BlockLength:
   Exclude:
@@ -36,14 +48,37 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 20
 
-Layout/EmptyLinesAroundBlockBody:
+
+Rails/HasAndBelongsToMany:
   Enabled: false
 
-Layout/EmptyLinesAroundClassBody:
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'app/models/preserved_object.rb' # because we're using touch on purpose
+
+
+RSpec/BeforeAfterAll:
+  Exclude:
+    - 'spec/models/preserved_object_spec.rb' # after(:all) is fine here
+
+RSpec/ExampleLength:
+  Max: 50
+
+RSpec/MessageSpies:
+  Exclude:
+    - 'spec/models/preserved_object_spec.rb' # have_received is a pain here
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - 'spec/controllers/moab_storage_controller_spec.rb'
+    - 'spec/models/preserved_object_spec.rb'
+
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/NamedSubject:
   Enabled: false
 
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
 
 Style/FileName:
   Exclude:
@@ -54,18 +89,5 @@ Style/StringLiterals:
   Enabled: false
 
 Style/SymbolArray:
-  Enabled: false
-
-RSpec/ExampleLength:
-  Max: 50
-
-RSpec/MultipleExpectations:
   Exclude:
-    - 'spec/controllers/moab_storage_controller_spec.rb'
-
-RSpec/NamedSubject:
-  Enabled: false
-
-Bundler/OrderedGems:
-  Exclude:
-    - 'Gemfile'
+    - 'Rakefile' # because [:spec, :rubocop ] isn't a big deal

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -4,12 +4,11 @@
 # represent a specific stored instance on a specific node, but aggregates
 # those instances.
 class PreservedObject < ApplicationRecord
-  # NOTE: The size field stored in PreservedObject is approximate,as it is determined from size
-  # on disk (which can vary from machine to machine). This field value should not be used for
-  # fixity checking!
   belongs_to :preservation_policy
   has_many :preservation_copies
-  validates :druid, presence: true, uniqueness: true
-  validates :current_version, presence: true
+  validates :druid, presence: true, uniqueness: true, format: { with: /\A[a-z]{2}\d{3}[a-z]{2}\d{4}\z/ }
+  validates :current_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  # NOTE: size here is approximate and not used for fixity checking
+  validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :preservation_policy, null: false
 end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -1,0 +1,159 @@
+# creating a PreservedObject and/or updating check timestamps may require interactions
+#  beyond the single PreservedObject model (e.g. PreservationCopy, PreservationPolicy).
+#  This service class encapsulates logic to keep the controller and the model object
+#    code simpler/thinner.
+# NOTE: performing validation here to allow this class to be called directly avoiding http overhead
+#
+# inspired by http://www.thegreatcodeadventure.com/smarter-rails-services-with-active-record-modules/
+class PreservedObjectHandler
+
+  INVALID_ARGUMENTS = 1
+  VERSION_MATCHES = 2
+  ARG_VERSION_GREATER_THAN_DB_OBJECT = 3
+  ARG_VERSION_LESS_THAN_DB_OBJECT = 4
+  UPDATED_DB_OBJECT = 5
+  UPDATED_DB_OBJECT_TIMESTAMP_ONLY = 6
+  CREATED_NEW_OBJECT = 7
+  DB_UPDATE_FAILED = 8
+
+  RESPONSE_CODE_TO_MESSAGES = {
+    INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
+    VERSION_MATCHES => "incoming version (%{incoming_version}) matches db version",
+    ARG_VERSION_GREATER_THAN_DB_OBJECT => "incoming version (%{incoming_version}) greater than db version",
+    ARG_VERSION_LESS_THAN_DB_OBJECT => "incoming version (%{incoming_version}) less than db version; ERROR!",
+    UPDATED_DB_OBJECT => "db object updated",
+    UPDATED_DB_OBJECT_TIMESTAMP_ONLY => "updated db timestamp only",
+    CREATED_NEW_OBJECT => "added object to db as it did not exist",
+    DB_UPDATE_FAILED => "db update failed: %{addl}"
+  }.freeze
+
+  include ActiveModel::Validations
+
+  # Note: supplying validations here to allow validation before use, e.g. incoming_version in numeric logic
+  validates :druid, presence: true, format: { with: /\A[a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4}\z/ }
+  validates :incoming_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :incoming_size, numericality: { only_integer: true, greater_than: 0 }
+
+  attr_reader :druid, :incoming_version, :incoming_size
+
+  def initialize(druid, incoming_version, incoming_size)
+    @druid = druid
+    @incoming_version = version_string_to_int(incoming_version)
+    @incoming_size = string_to_int(incoming_size)
+  end
+
+  def update_or_create
+    results = []
+
+    if invalid?
+      results << result_hash(INVALID_ARGUMENTS, errors.full_messages)
+    elsif PreservedObject.exists?(druid: druid)
+      Rails.logger.debug "update #{druid} called and object exists"
+
+      db_object = PreservedObject.find_by(druid: druid)
+      results << update_per_version_comparison(db_object)
+    else
+      pp_default = PreservationPolicy.create(preservation_policy_name: 'default',
+                                             archive_ttl: 604_800,
+                                             fixity_ttl: 604_800)
+      PreservedObject.create(druid: druid,
+                             current_version: incoming_version,
+                             size: incoming_size,
+                             preservation_policy: pp_default)
+      results << result_hash(CREATED_NEW_OBJECT)
+    end
+    results.flatten!
+    log_results(results)
+    results
+  end
+
+  private
+
+  # expects @incoming_version to be numeric
+  # TODO: update existence check timestamps/status per each flavor of comparison?
+  def update_per_version_comparison(db_object)
+    version_comparison = db_object.current_version <=> incoming_version
+    results = []
+    if version_comparison.zero?
+      results << result_hash(VERSION_MATCHES)
+    elsif version_comparison == 1
+      # TODO: needs manual intervention until automatic recovery services implemented
+      results << result_hash(ARG_VERSION_LESS_THAN_DB_OBJECT)
+    elsif version_comparison == -1
+      db_object.current_version = incoming_version
+      db_object.size = incoming_size if incoming_size
+      results << result_hash(ARG_VERSION_GREATER_THAN_DB_OBJECT)
+    end
+
+    update_db_object(db_object, results)
+    results.flatten
+  end
+
+  # TODO: this may need reworking if we need to distinguish db timestamp updates when
+  #   version matched vs. incoming version less than db object
+  def update_db_object(db_object, results)
+    if db_object.changed?
+      db_object.save
+      results << result_hash(UPDATED_DB_OBJECT)
+    else
+      # FIXME: we may not want to do this, but instead to update specific timestamp for check
+      db_object.touch
+      results << result_hash(UPDATED_DB_OBJECT_TIMESTAMP_ONLY)
+    end
+  rescue ActiveRecord::ActiveRecordError => e
+    results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
+  end
+
+  def result_hash(response_code, addl=nil)
+    { response_code => result_code_msg(response_code, addl) }
+  end
+
+  def result_code_msg(response_code, addl=nil)
+    "#{result_msg_prefix} #{RESPONSE_CODE_TO_MESSAGES[response_code] % { incoming_version: incoming_version, addl: addl }}"
+  end
+
+  def result_msg_prefix
+    @msg_prefix ||= "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})"
+  end
+
+  # results = [result1, result2]
+  # result1 = {response_code => msg}
+  # result2 = {response_code => msg}
+  def log_results(results)
+    results.each do |r|
+      severity = logger_severity_level(r.keys.first)
+      msg = r.values.first
+      # Rails.logger.log(severity, msg, 'PreservedObjectHandler')
+      Rails.logger.log(severity, msg)
+    end
+  end
+
+  def logger_severity_level(result_code)
+    case result_code
+    when INVALID_ARGUMENTS then Logger::ERROR
+    when VERSION_MATCHES then Logger::INFO
+    when ARG_VERSION_GREATER_THAN_DB_OBJECT then Logger::INFO
+    when ARG_VERSION_LESS_THAN_DB_OBJECT then Logger::ERROR
+    when UPDATED_DB_OBJECT then Logger::INFO
+    when UPDATED_DB_OBJECT_TIMESTAMP_ONLY then Logger::INFO
+    when CREATED_NEW_OBJECT then Logger::WARN
+    when DB_UPDATE_FAILED then Logger::ERROR
+    end
+  end
+
+  def version_string_to_int(val)
+    result = string_to_int(val)
+    return result if result.instance_of?(Integer)
+    # accommodate 'vnnn' strings from Moab version directories
+    return val[1..-1].to_i if val.instance_of?(String) && val.match(/^v\d+$/)
+    val
+  end
+
+  def string_to_int(val)
+    return if val.blank?
+    return val if val.instance_of?(Integer) # NOTE: negative integers caught with validation
+    return val.to_i if val.instance_of?(String) && val.scan(/\D/).empty?
+    val
+  end
+
+end

--- a/spec/models/preservation_copy_spec.rb
+++ b/spec/models/preservation_copy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PreservationCopy, type: :model do
 
   let!(:preserved_object) do
     PreservedObject.create!(
-      druid: 'ab123cd45679', current_version: 1, preservation_policy_id: preservation_policy.id, size: 1
+      druid: 'ab123cd4567', current_version: 1, preservation_policy_id: preservation_policy.id, size: 1
     )
   end
   let!(:status) { Status.create!(status_text: 'ok') }

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreservedObject, type: :model do
 
   let(:required_attributes) do
     {
-      druid: 'ab123cd45678',
+      druid: 'ab123cd4567',
       current_version: 1,
       preservation_policy: preservation_policy
     }

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -1,0 +1,384 @@
+require 'rails_helper'
+
+RSpec.describe PreservedObjectHandler do
+  let(:druid) { 'ab123cd4567' }
+  let(:incoming_version) { 6 }
+  let(:incoming_size) { 9876 }
+
+  describe '#initialize' do
+    it 'sets druid' do
+      po_handler = described_class.new(druid, incoming_version, nil)
+      expect(po_handler.druid).to eq druid
+    end
+    context 'sets incoming_version' do
+      { # passed value => expected parsed value
+        6 => 6,
+        0 => 0,
+        -1 => -1,
+        '6' => 6,
+        '006' => 6,
+        'v0006' => 6,
+        '0' => 0,
+        '-666' => '-666',
+        'vv001' => 'vv001',
+        'asdf' => 'asdf'
+      }.each do |k, v|
+        it "by parsing '#{k}' to '#{v}'" do
+          po_handler = described_class.new(druid, k, nil)
+          expect(po_handler.incoming_version).to eq v
+        end
+      end
+    end
+    context 'sets incoming_size' do
+      { # passed value => expected parsed value
+        6 => 6,
+        0 => 0,
+        -1 => -1,
+        '0' => 0,
+        '6' => 6,
+        '006' => 6,
+        'v0006' => 'v0006',
+        '-666' => '-666',
+        'vv001' => 'vv001',
+        'asdf' => 'asdf'
+      }.each do |k, v|
+        it "by parsing '#{k}' to '#{v}'" do
+          po_handler = described_class.new(druid, nil, k)
+          expect(po_handler.incoming_size).to eq v
+        end
+      end
+    end
+  end
+
+  describe '#update_or_create' do
+    let!(:default_prez_policy) do
+      PreservationPolicy.create!(preservation_policy_name: 'default',
+                                 archive_ttl: 604_800,
+                                 fixity_ttl: 604_800)
+    end
+
+    context 'logs errors and returns INVALID_ARGUMENTS if ActiveModel::Validations fail' do
+      let(:bad_druid) { '666' }
+      let(:bad_version) { 'vv666' }
+      let(:bad_size) { '-666' }
+
+      context 'returns' do
+        let!(:result) do
+          po_handler = described_class.new(bad_druid, bad_version, bad_size)
+          po_handler.update_or_create
+        end
+
+        it '1 result' do
+          expect(result).to be_an_instance_of Array
+          expect(result.size).to eq 1
+        end
+        it 'INVALID_ARGUMENTS' do
+          expect(result).to include(a_hash_including(PreservedObjectHandler::INVALID_ARGUMENTS))
+        end
+        context 'result message includes' do
+          let(:msg) { result.first[PreservedObjectHandler::INVALID_ARGUMENTS] }
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_size})" }
+
+          it "prefix" do
+            expect(msg).to match(Regexp.escape("#{exp_msg_prefix} encountered validation error(s): "))
+          end
+          it "druid error" do
+            expect(msg).to match(/Druid is invalid/)
+          end
+          it "version error" do
+            expect(msg).to match(/Incoming version is not a number/)
+          end
+          it "size error" do
+            expect(msg).to match(/Incoming size must be greater than 0/)
+          end
+        end
+      end
+      it 'bad druid error is written to Rails log' do
+        po_handler = described_class.new(bad_druid, incoming_version, incoming_size)
+        err_msg = "PreservedObjectHandler(#{bad_druid}, #{incoming_version}, #{incoming_size}) encountered validation error(s): [\"Druid is invalid\"]"
+        allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
+        po_handler.update_or_create
+        expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
+      end
+      it 'bad version error is written to Rails log' do
+        po_handler = described_class.new(druid, bad_version, incoming_size)
+        err_msg = "PreservedObjectHandler(#{druid}, #{bad_version}, #{incoming_size}) encountered validation error(s): [\"Incoming version is not a number\"]"
+        allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
+        po_handler.update_or_create
+        expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
+      end
+      it 'bad size error is written to Rails log' do
+        po_handler = described_class.new(druid, incoming_version, bad_size)
+        err_msg = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{bad_size}) encountered validation error(s): [\"Incoming size must be greater than 0\"]"
+        allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
+        po_handler.update_or_create
+        expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
+      end
+    end
+
+    context 'druid in db' do
+      before do
+        po = PreservedObject.find_by(druid: druid)
+        po.destroy if po
+        PreservedObject.create!(druid: druid, current_version: 2, size: 1, preservation_policy: default_prez_policy)
+      end
+      after do
+        po = PreservedObject.find_by(druid: druid)
+        po.destroy if po
+      end
+      let(:po_handler) { described_class.new(druid, incoming_version, incoming_size) }
+      let(:po) { PreservedObject.find_by(druid: druid) }
+
+      context "incoming and db versions match" do
+        let(:po_handler) { described_class.new(druid, 2, 1) }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, 1)" }
+        let(:version_matches_msg) { "#{exp_msg_prefix} incoming version (2) matches db version" }
+        let(:updated_db_timestamp_msg) { "#{exp_msg_prefix} updated db timestamp only" }
+
+        it "entry version stays the same" do
+          expect(po.current_version).to eq 2
+          po_handler.update_or_create
+          expect(po.reload.current_version).to eq 2
+        end
+        it "entry size stays the same" do
+          expect(po.size).to eq 1
+          po_handler.update_or_create
+          expect(po.reload.size).to eq 1
+        end
+        it "logs at info level" do
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_matches_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_db_timestamp_msg)
+          po_handler.update_or_create
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_matches_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_db_timestamp_msg)
+        end
+        context 'returns' do
+          let!(:results) { po_handler.update_or_create }
+
+          # results = [result1, result2]
+          # result1 = {response_code: msg}
+          # result2 = {response_code: msg}
+          it '2 results' do
+            expect(results).to be_an_instance_of Array
+            expect(results.size).to eq 2
+          end
+          it 'VERSION_MATCHES result' do
+            result_msg = results.select { |r| r[PreservedObjectHandler::VERSION_MATCHES] }.first.values.first
+            expect(result_msg).to match(Regexp.escape(version_matches_msg))
+          end
+          it "UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+            result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.first.values.first
+            expect(result_msg).to match(Regexp.escape(updated_db_timestamp_msg))
+          end
+        end
+      end
+
+      context 'incoming version newer than db version' do
+        let(:po_handler) { described_class.new(druid, incoming_version, incoming_size) }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})" }
+        let(:version_gt_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than db version" }
+        let(:updated_db_msg) { "#{exp_msg_prefix} db object updated" }
+
+        it "updates entry with incoming version" do
+          expect(po.current_version).to eq 2
+          po_handler.update_or_create
+          expect(po.reload.current_version).to eq incoming_version
+        end
+        it 'updates entry with size if included' do
+          expect(po.size).to eq 1
+          po_handler.update_or_create
+          expect(po.reload.size).to eq incoming_size
+        end
+        it 'retains old size if incoming size is nil' do
+          expect(po.size).to eq 1
+          po_handler = described_class.new(druid, incoming_version, nil)
+          po_handler.update_or_create
+          expect(po.reload.size).to eq 1
+        end
+        it "logs at info level" do
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_db_msg)
+          po_handler.update_or_create
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_gt_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_db_msg)
+        end
+        context 'returns' do
+          let!(:results) { po_handler.update_or_create }
+
+          # results = [result1, result2]
+          # result1 = {response_code: msg}
+          # result2 = {response_code: msg}
+          it '2 results' do
+            expect(results).to be_an_instance_of Array
+            expect(results.size).to eq 2
+          end
+          it 'ARG_VERSION_GREATER_THAN_DB_OBJECT result' do
+            result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT] }.first.values.first
+            expect(result_msg).to match(Regexp.escape(version_gt_msg))
+          end
+          it "UPDATED_DB_OBJECT result" do
+            result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT] }.first.values.first
+            expect(result_msg).to match(Regexp.escape(updated_db_msg))
+          end
+        end
+      end
+
+      context 'incoming version older than db version' do
+        let(:po_handler) { described_class.new(druid, 1, 666) }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, 666)" }
+        let(:version_less_than_msg) { "#{exp_msg_prefix} incoming version (1) less than db version; ERROR!" }
+        let(:updated_db_timestamp_msg) { "#{exp_msg_prefix} updated db timestamp only" }
+
+        it "entry version stays the same" do
+          expect(po.current_version).to eq 2
+          po_handler.update_or_create
+          expect(po.reload.current_version).to eq 2
+        end
+        it "entry size stays the same" do
+          expect(po.size).to eq 1
+          po_handler.update_or_create
+          expect(po.reload.size).to eq 1
+        end
+        it "logs at error level" do
+          allow(Rails.logger).to receive(:log).with(Logger::ERROR, version_less_than_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_db_timestamp_msg)
+          po_handler.update_or_create
+          expect(Rails.logger).to have_received(:log).with(Logger::ERROR, version_less_than_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_db_timestamp_msg)
+        end
+        context 'returns' do
+          let!(:results) { po_handler.update_or_create }
+
+          # results = [result1, result2]
+          # result1 = {response_code: msg}
+          # result2 = {response_code: msg}
+          it '2 results' do
+            expect(results).to be_an_instance_of Array
+            expect(results.size).to eq 2
+          end
+          it 'ARG_VERSION_LESS_THAN_DB_OBJECT result' do
+            result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT] }.first.values.first
+            expect(result_msg).to match(Regexp.escape(version_less_than_msg))
+          end
+          # FIXME: do we want to update timestamp if we found an error (ARG_VERSION_LESS_THAN_DB_OBJECT)
+          it "UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+            result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.first.values.first
+            expect(result_msg).to match(Regexp.escape(updated_db_timestamp_msg))
+          end
+        end
+      end
+
+      context 'db update error' do
+        context 'ActiveRecordError' do
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})" }
+          let(:db_update_failed_prefix) { "#{exp_msg_prefix} db update failed" }
+          let(:results) do
+            allow(Rails.logger).to receive(:log)
+            # FIXME: couldn't figure out how to put next line into its own test
+            expect(Rails.logger).to receive(:log).with(Logger::ERROR, /#{Regexp.escape(db_update_failed_prefix)}/)
+
+            po = instance_double("PreservedObject")
+            allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+            allow(po).to receive(:current_version).and_return(1)
+            allow(po).to receive(:current_version=).with(incoming_version)
+            allow(po).to receive(:size=).with(incoming_size)
+            allow(po).to receive(:changed?).and_return(true)
+            allow(po).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+            allow(po).to receive(:destroy) # for after() cleanup calls
+            po_handler.update_or_create
+          end
+
+          it 'DB_UPDATED_FAILED error' do
+            expect(results).to include(a_hash_including(PreservedObjectHandler::DB_UPDATE_FAILED))
+          end
+          context 'error message' do
+            let(:result_msg) { results.select { |r| r[PreservedObjectHandler::DB_UPDATE_FAILED] }.first.values.first }
+
+            it 'prefix' do
+              expect(result_msg).to match(Regexp.escape(db_update_failed_prefix))
+            end
+            it 'specific exception raised' do
+              expect(result_msg).to match(Regexp.escape('ActiveRecord::ActiveRecordError'))
+            end
+            it "exception's message" do
+              expect(result_msg).to match(Regexp.escape('foo'))
+            end
+          end
+        end
+      end
+
+      it 'calls PreservedObject.save if the existing record is altered' do
+        po = instance_double(PreservedObject)
+        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+        allow(po).to receive(:current_version).and_return(1)
+        allow(po).to receive(:current_version=).with(incoming_version)
+        allow(po).to receive(:size=).with(incoming_size)
+        allow(po).to receive(:changed?).and_return(true)
+        allow(po).to receive(:save)
+        po_handler.update_or_create
+        expect(po).to have_received(:save)
+
+        allow(po).to receive(:destroy)
+      end
+      it 'calls PreservedObject.touch if the existing record is NOT altered' do
+        po_handler = described_class.new(druid, 1, 1)
+        po = instance_double(PreservedObject)
+        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+        allow(po).to receive(:current_version).and_return(1)
+        allow(po).to receive(:changed?).and_return(false)
+        allow(po).to receive(:touch)
+        po_handler.update_or_create
+        expect(po).to have_received(:touch)
+
+        allow(po).to receive(:destroy)
+      end
+      it 'logs a debug message' do
+        msg = "update #{druid} called and object exists"
+        allow(Rails.logger).to receive(:debug)
+        po_handler.update_or_create
+        expect(Rails.logger).to have_received(:debug).with(msg)
+      end
+    end
+
+    context 'druid not in db (yet)' do
+      after do
+        po = PreservedObject.find_by(druid: druid)
+        po.destroy if po
+      end
+      let(:po_handler) { described_class.new(druid, incoming_version, incoming_size) }
+      let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})" }
+      let(:exp_msg) { "#{exp_msg_prefix} added object to db as it did not exist" }
+
+      it 'creates the object' do
+        args = {
+          druid: druid,
+          current_version: incoming_version,
+          size: incoming_size,
+          preservation_policy: an_instance_of(PreservationPolicy)
+        }
+        allow(PreservedObject).to receive(:create).with(args)
+        po_handler.update_or_create
+        expect(PreservedObject).to have_received(:create).with(args)
+      end
+      it 'logs a warning' do
+        allow(Rails.logger).to receive(:log).with(Logger::WARN, exp_msg)
+        po_handler.update_or_create
+        expect(Rails.logger).to have_received(:log).with(Logger::WARN, exp_msg)
+      end
+      context 'returns' do
+        let!(:result) { po_handler.update_or_create }
+
+        it '1 result' do
+          expect(result).to be_an_instance_of Array
+          expect(result.size).to eq 1
+        end
+        it 'CREATED_NEW_OBJECT result' do
+          result_code = result.first.keys.first
+          expect(result_code).to eq PreservedObjectHandler::CREATED_NEW_OBJECT
+          result_msg = result.first.values.first
+          expect(result_msg).to match(Regexp.escape(exp_msg))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Service for heaving lifting for existence check from online Moab storage_roots to PCC db.  Has logic for update/create of PreservedObject as indicated by comparison of online Moab object's current version (and size) with what is in PCC db.

Idea is that controller can do:

```ruby
po_handler = PreservedObjectHandler(druid, version, size)
results = po_handler.update_or_create
```

and look at details in results to determine what HTTP response to send.

Additionally, code on the same machine could instantiate `PreservedObjectHandler` directly and avoid the overhead of the HTTP call.

Connected to #65 
Closes #90 (what to do when storage root moab is older than db)
Closes #81  (when to update size)

Implemented the most basic interpretation of method to update db table entry:

if entry already exists:
- [x] `updated_at` field is updated
- [x] deals with the three different cases of current_version (between incoming and db - see code) 
- [x] log level "info" - stating check happened;  rails log for now (see #66 for logging)

if entry doesn't exist yet:
- [x] log level "warn": expected object xx but it wasn't there;  rails log for now (see #66 for logging)
- [x] add entry  (as entry in single table)

Creating ticket for creation of preservation_copy object.