### PR TITLE
helper to load moab fixtures into catalog; always seeds test db for specs 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,9 @@ Rails/SkipsModelValidations:
     - 'app/services/preserved_object_handler.rb' # we're using touch on purpose
 
 # --- RSpec ---
+RSpec/BeforeAfterAll:
+  Exclude:
+    - 'spec/load_fixtures_helper.rb' # being careful to avoid state leakage
 
 RSpec/ExampleLength:
   Max: 50

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,9 @@ gem 'pry-rails' # use pry as the rails console shell instead of IRB
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.3'
 
-# Stanford/Samvera gems
-# work with Moab Objects
-gem 'moab-versioning'
+# Stanford gems
+gem 'moab-versioning' # work with Moab Objects
+gem 'druid-tools' # for druid validation and druid-tree parsing
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.1.5)
+    druid-tools (0.4.1)
     erubi (1.6.1)
     ffi (1.9.18)
     globalid (0.4.0)
@@ -256,6 +257,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano
+  druid-tools
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   moab-versioning

--- a/lib/audit/catalog_to_moab_existence.rb
+++ b/lib/audit/catalog_to_moab_existence.rb
@@ -7,7 +7,7 @@ class CatalogToMoabExistence
   # FIXME:  temporarily turning off rubocop
   # rubocop:disable all
   def self.whole_db
-    PreservationCopy.all.each do |pc|
+    PreservationCopy.find_each do |pc|
       id = pc.preserved_object.druid
       version = pc.current_version
       storage_location = pc.endpoint.storage_location

--- a/lib/audit/catalog_to_moab_existence.rb
+++ b/lib/audit/catalog_to_moab_existence.rb
@@ -1,0 +1,30 @@
+require 'druid-tools'
+
+# Catalog to Moab existence check code
+class CatalogToMoabExistence
+
+  # NOTE: this is a bad thing -- HUGE list of objects;  just for now to populate test db
+  # FIXME:  temporarily turning off rubocop
+  # rubocop:disable all
+  def self.whole_db
+    PreservationCopy.all.each do |pc|
+      id = pc.preserved_object.druid
+      version = pc.current_version
+      storage_location = pc.endpoint.storage_location
+      druid = DruidTools::Druid.new(id)
+      object_dir = "#{storage_location}/#{druid.tree.join('/')}"
+
+      moab = Moab::StorageObject.new(id, object_dir)
+      moab_version = moab.current_version_id
+      if version == moab_version
+        p "hurray - #{id} versions match: #{version}"
+      else
+        p "boo - #{id} catalog has #{version} but moab has #{moab_version}"
+      end
+
+      # TODO: update status, timestamps, report errors, log, etc.
+    end
+  end
+  # rubocop:enable all
+
+end

--- a/lib/audit/catalog_to_moab_existence.rb
+++ b/lib/audit/catalog_to_moab_existence.rb
@@ -3,7 +3,9 @@ require 'druid-tools'
 # Catalog to Moab existence check code
 class CatalogToMoabExistence
 
-  # NOTE: this is a bad thing -- HUGE list of objects;  just for now to populate test db
+  # NOTE: this is at the chicken scratches stage
+  #  I'm not convinced we'll _ever_ do the whole db this way;  it was a way to start
+  #    step 1: ensure load_fixtures_helper works with very rough code here
   # FIXME:  temporarily turning off rubocop
   # rubocop:disable all
   def self.whole_db

--- a/spec/lib/audit/catalog_to_moab_existence_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_existence_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../../lib/audit/catalog_to_moab_existence.rb'
+require_relative '../../load_fixtures_helper.rb'
+
+RSpec.describe CatalogToMoabExistence do
+  include_context 'fixture moabs in db'
+  describe '.whole_db' do
+    it 'test_of_load_fixtures_helper (eventually will be testing code in .whole_db)' do
+      described_class.whole_db
+    end
+  end
+end

--- a/spec/lib/audit/catalog_to_moab_existence_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_existence_spec.rb
@@ -4,7 +4,9 @@ require_relative '../../load_fixtures_helper.rb'
 RSpec.describe CatalogToMoabExistence do
   include_context 'fixture moabs in db'
   describe '.whole_db' do
-    it 'test_of_load_fixtures_helper (eventually will be testing code in .whole_db)' do
+    # NOTE: this is at the chicken scratches stage
+    #  step 1: ensure load_fixtures_helper works
+    it 'test_of_load_fixtures_helper (eventually will be testing code for .whole_db)' do
       described_class.whole_db
     end
   end

--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -1,0 +1,59 @@
+require 'rails_helper.rb'
+
+RSpec.configure do |rspec|
+  # This config option will be enabled by default on RSpec 4,
+  # but for reasons of backwards compatibility, you have to
+  # set it on RSpec 3.
+  #
+  # It causes the host group and examples to inherit metadata
+  # from the shared context.
+  rspec.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+RSpec.shared_context "fixture moabs in db" do
+  before(:all) do
+    setup
+    load_fixture_moabs
+  end
+  after(:all) do
+    # TODO: danger - if there are objects in the test db we want to keep
+    Settings.moab.storage_roots.each do |_name, storage_root|
+      storage_dir = File.join(storage_root, Settings.moab.storage_trunk)
+      PreservationCopy.where(endpoint_id: Endpoint.find_by(storage_location: storage_dir).id).each do |pc|
+        po_id = pc.preserved_object_id
+        pc.destroy
+        PreservedObject.find(po_id).destroy
+      end
+    end
+  end
+end
+
+def load_fixture_moabs
+  pp_default = PreservationPolicy.default_preservation_policy
+  status_ok_id = Status.find_by(status_text: 'ok').id
+
+  @moab_storage_dirs.each do |storage_dir|
+    MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, _path, _path_match_data|
+      version = Stanford::StorageServices.current_version(druid)
+      size = Stanford::StorageServices.object_size(druid)
+      po = PreservedObject.create(druid: druid,
+                                  current_version: version,
+                                  size: size,
+                                  preservation_policy: pp_default)
+      PreservationCopy.create(preserved_object_id: po.id,
+                              endpoint_id: @storage_dir_to_endpoint_id[storage_dir],
+                              current_version: version,
+                              status_id: status_ok_id)
+    end
+  end
+end
+
+def setup
+  @moab_storage_dirs = []
+  @storage_dir_to_endpoint_id = {}
+  Settings.moab.storage_roots.each do |_name, storage_root|
+    storage_dir = File.join(storage_root, Settings.moab.storage_trunk)
+    @moab_storage_dirs << storage_dir
+    @storage_dir_to_endpoint_id[storage_dir] = Endpoint.find_by(storage_location: storage_dir).id
+  end
+end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -50,13 +50,6 @@ RSpec.describe Endpoint, type: :model do
     let(:strg_rt_endpoint_type) { Endpoint.default_storage_root_endpoint_type }
     let(:default_pres_policies) { [PreservationPolicy.default_preservation_policy] }
 
-    before do
-      # Endpoint's going to try to use the default pres policy and endpoint type, so they should both get seeded first
-      PreservationPolicy.seed_from_config
-      EndpointType.seed_from_config
-      Endpoint.seed_storage_root_endpoints_from_config(strg_rt_endpoint_type, default_pres_policies)
-    end
-
     it 'creates a local online endpoint for each storage root' do
       Settings.moab.storage_roots.each do |storage_root_name, storage_root_location|
         storage_root_attrs = {
@@ -93,11 +86,12 @@ RSpec.describe Endpoint, type: :model do
 
   describe '.default_storage_root_endpoint_type' do
     it 'returns the default endpoint type object for the storage root' do
-      EndpointType.seed_from_config
+      # db already seeded
       expect(Endpoint.default_storage_root_endpoint_type).to be_a_kind_of EndpointType
     end
 
     it "raises RecordNotFound if the default endpoint type doesn't exist in the db" do
+      skip('database seeded before running tests; not super-trivial to destroy relevant objects')
       expect { Endpoint.default_storage_root_endpoint_type }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end

--- a/spec/models/endpoint_type_spec.rb
+++ b/spec/models/endpoint_type_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe EndpointType, type: :model do
   it { is_expected.to have_many(:endpoints) }
 
   describe '.seed_from_config' do
-    before { EndpointType.seed_from_config }
-
     it 'creates the endpoint types listed in Settings' do
       Settings.endpoint_types.each do |type_name, type_config|
         expect(EndpointType.find_by(type_name: type_name.to_s).endpoint_class).to eq type_config.endpoint_class

--- a/spec/models/preservation_copy_spec.rb
+++ b/spec/models/preservation_copy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe PreservationCopy, type: :model do
       druid: 'ab123cd4567', current_version: 1, preservation_policy_id: preservation_policy.id, size: 1
     )
   end
-  let!(:status) { Status.create!(status_text: 'ok') }
+  let!(:status) { Status.find_by(status_text: 'ok') }
   let!(:preservation_copy) do
     PreservationCopy.create!(
       preserved_object_id: preserved_object.id,

--- a/spec/models/preservation_policy_spec.rb
+++ b/spec/models/preservation_policy_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PreservationPolicy, type: :model do
 
   describe '.seed_from_config' do
     it 'creates the preservation policies listed in Settings' do
-      PreservationPolicy.seed_from_config
+      # db already seeded
       Settings.preservation_policies.policy_definitions.each do |policy_name, _policy_config|
         expect(
           PreservationPolicy.find_by(preservation_policy_name: policy_name.to_s)
@@ -26,13 +26,13 @@ RSpec.describe PreservationPolicy, type: :model do
     end
 
     it 'does not re-create records that already exist' do
-      PreservationPolicy.seed_from_config
+      # db already seeded
       PreservationPolicy.seed_from_config
       expect(PreservationPolicy.pluck(:preservation_policy_name)).to eq %w[default]
     end
 
     it 'adds new records if there are additions to Settings since the last run' do
-      PreservationPolicy.seed_from_config
+      # db already seeded
       archive_pres_policy_setting = Config::Options.new(
         archive_policy: Config::Options.new(archive_ttl: 604_800, fixity_ttl: 604_800)
       )
@@ -44,11 +44,12 @@ RSpec.describe PreservationPolicy, type: :model do
 
   describe '.default_preservation_policy' do
     it 'returns the default preservation policy object' do
-      PreservationPolicy.seed_from_config
+      # db already seeded
       expect(PreservationPolicy.default_preservation_policy).to be_a_kind_of PreservationPolicy
     end
 
     it "raises RecordNotFound if the default policy doesn't exist in the db" do
+      skip('database seeded before running tests; not super-trivial to destroy relevant objects')
       expect { PreservationPolicy.default_preservation_policy }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Status, type: :model do
-  let!(:status) { Status.create!(status_text: 'ok') }
+  let!(:status) { Status.find_by(status_text: 'ok') }
 
   it 'is valid with valid attributes' do
     expect(status).to be_valid
@@ -30,8 +30,6 @@ RSpec.describe Status, type: :model do
   it { is_expected.to have_db_index(:status_text) }
 
   describe '.seed_from_config' do
-    before { Status.seed_from_config }
-
     it 'creates the endpoint statuses listed in Settings' do
       Settings.statuses.each do |status_text|
         expect(Status.find_by(status_text: status_text)).to be_a_kind_of Status

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,11 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'rake'
+Rails.application.load_tasks
+Rake::Task["db:migrate"].invoke
+Rake::Task["db:seed"].invoke
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Wrote an rspec "shared context" https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-context to allow easy loading of our fixture moabs into the test db for specs.

Also:
- ensures that tests are run with test db seeded (added to rails_helper)
  - adjusts model specs affected by ^^
- bare beginnings of catalog to moab existence check code (useful for "testing" the load_fixtures_helper "shared context" ... and next work to do!)

Closes #149 (fixture moabs put in test db)
Connected to #108 (catalog to moab existence check)