### PR TITLE
refactor the way in which we get current version of a moab

### DIFF
--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -3,10 +3,11 @@
 class MoabToCatalog
   def self.check_moab_to_catalog_existence(storage_dir)
     results = []
-    MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, _path, _path_match_data|
-      storage_root_current_version = Stanford::StorageServices.current_version(druid)
-      storage_root_size = Stanford::StorageServices.object_size(druid)
-      po_handler = PreservedObjectHandler.new(druid, storage_root_current_version, storage_root_size)
+    MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
+      moab = Moab::StorageObject.new(druid, path)
+      moab_current_version = moab.current_version_id
+      moab_size = Stanford::StorageServices.object_size(druid)
+      po_handler = PreservedObjectHandler.new(druid, moab_current_version, moab_size)
       results << po_handler.update_or_create
     end
     results


### PR DESCRIPTION
To avoid looking at storage roots unnecessarily, instead of 

```ruby
current_version = Stanford::StorageServices.current_version(druid)
```

do 
```ruby
moab = Moab::StorageObject.new(druid, object_dir)
moab_version = moab.current_version_id  # this should be cheaper as it instantiates fewer objects to get version number
```

connects #167