### PR TITLE
split `PreservedObjectHandler#update_or_create` into separate `#update` and `#create` methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,7 +55,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 120
+  Max: 200
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -69,7 +69,7 @@ Metrics/LineLength:
     - 'spec/services/preserved_object_handler_spec.rb' # 3 lines are longer
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
 
 # --- Naming ---
 
@@ -101,7 +101,7 @@ RSpec/ExampleLength:
   Max: 50
 
 RSpec/MultipleExpectations:
-  Max: 2
+  Max: 4
 
 RSpec/MessageSpies:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'ruby-prof'
+  gem 'hirb' # for db table display via rails console
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     hashie (3.5.6)
+    hirb (0.7.3)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -258,6 +259,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano
   druid-tools
+  hirb
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   moab-versioning

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -1,14 +1,19 @@
 ##
 # Method that will check the a single moab service disk for the existence of moabs in postgres database
 class MoabToCatalog
-  def self.check_moab_to_catalog_existence(storage_dir)
+  def self.check_moab_to_catalog_existence(storage_dir, expect_to_create=false)
     results = []
     MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
       moab = Moab::StorageObject.new(druid, path)
       moab_current_version = moab.current_version_id
       moab_size = Stanford::StorageServices.object_size(druid)
-      po_handler = PreservedObjectHandler.new(druid, moab_current_version, moab_size)
-      results << po_handler.update_or_create
+      po_handler = PreservedObjectHandler.new(druid, moab_current_version, moab_size, storage_dir)
+      if PreservedObject.exists?(druid: druid)
+        results << po_handler.update
+      else
+        Rails.logger.error "druid: #{druid} expected to exist in catalog but was not found" unless expect_to_create
+        results << po_handler.create
+      end
     end
     results
   end

--- a/lib/benchmarking/moab_to_catalog_testing.rb
+++ b/lib/benchmarking/moab_to_catalog_testing.rb
@@ -7,9 +7,9 @@ require 'ruby-prof'
 
 logger = Logger.new('log/benchmark_moab_to_catalog.log')
 at_exit do # #{pcc_app_home}/current/log/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
-
   # File.open "/tmp/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
   # RubyProf::FlatPrinter.new(@prof).print(file)
+
   # end
   logger.info "Benchmarking stopped at #{Time.now.getlocal}"
 end
@@ -34,13 +34,12 @@ sleep(10)
 # this is coming from config/settings.yml and config/initializers
 Stanford::StorageServices.storage_roots.each do |storage_root|
   time_to_check_existence = Benchmark.realtime do
-    RubyProf.start
+    # RubyProf.start
     logger.info "Check for output"
-
     MoabToCatalog.check_moab_to_catalog_existence(File.join(storage_root, Moab::Config.storage_trunk))
     # when creating add true parameter, and if updating leave blank
     # @prof = RubyProf.stop
   end
+  logger.info time_to_check_existence.to_s
+  logger.info "It took #{time_to_check_existence} seconds to check the database w/ online moab"
 end
-logger.info time_to_check_existence.to_s
-logger.info "It took #{time_to_check_existence} seconds to check the database w/ online moab"

--- a/lib/benchmarking/moab_to_catalog_testing.rb
+++ b/lib/benchmarking/moab_to_catalog_testing.rb
@@ -1,13 +1,16 @@
+# bin/rails runner lib/benchmark/moab_to_catalog_testing.rb
+
 require 'benchmark'
 require 'logger'
 require_relative "../audit/moab_to_catalog.rb"
 require 'ruby-prof'
 
 logger = Logger.new('log/benchmark_moab_to_catalog.log')
-at_exit do # File.open "/tmp/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
-  File.open "#{pcc_app_home}/current/log/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
-    RubyProf::FlatPrinter.new(@prof).print(file)
-  end
+at_exit do # #{pcc_app_home}/current/log/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
+
+  # File.open "/tmp/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
+  # RubyProf::FlatPrinter.new(@prof).print(file)
+  # end
   logger.info "Benchmarking stopped at #{Time.now.getlocal}"
 end
 
@@ -26,13 +29,18 @@ else
   logger.info "at revision #{commit}"
 end
 sleep(10)
-# storage_dir = 'spec/fixtures/moab_storage_root'
-storage_dir = '/services-disk12/sdr2objects'
-time_to_check_existence = Benchmark.realtime do
-  RubyProf.start
-  logger.info "Check for output"
-  StorageRootToDB.check_moab_to_catalog_existence(storage_dir)
-  @prof = RubyProf.stop
+# storage_dir = 'spec/fixtures/storage_root01/moab_storage_trunk'
+# storage_dir = '/services-disk12/sdr2objects'
+# this is coming from config/settings.yml and config/initializers
+Stanford::StorageServices.storage_roots.each do |storage_root|
+  time_to_check_existence = Benchmark.realtime do
+    RubyProf.start
+    logger.info "Check for output"
+
+    MoabToCatalog.check_moab_to_catalog_existence(File.join(storage_root, Moab::Config.storage_trunk))
+    # when creating add true parameter, and if updating leave blank
+    # @prof = RubyProf.stop
+  end
 end
 logger.info time_to_check_existence.to_s
 logger.info "It took #{time_to_check_existence} seconds to check the database w/ online moab"

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe PreservedObjectHandler do
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
+  let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' } # we are just going to assume the first rails storage root
 
   describe '#initialize' do
     it 'sets druid' do
-      po_handler = described_class.new(druid, incoming_version, nil)
+      po_handler = described_class.new(druid, incoming_version, nil, storage_dir)
       expect(po_handler.druid).to eq druid
     end
     context 'sets incoming_version' do
@@ -24,7 +25,7 @@ RSpec.describe PreservedObjectHandler do
         'asdf' => 'asdf'
       }.each do |k, v|
         it "by parsing '#{k}' to '#{v}'" do
-          po_handler = described_class.new(druid, k, nil)
+          po_handler = described_class.new(druid, k, nil, storage_dir)
           expect(po_handler.incoming_version).to eq v
         end
       end
@@ -43,25 +44,92 @@ RSpec.describe PreservedObjectHandler do
         'asdf' => 'asdf'
       }.each do |k, v|
         it "by parsing '#{k}' to '#{v}'" do
-          po_handler = described_class.new(druid, nil, k)
+          po_handler = described_class.new(druid, nil, k, storage_dir)
           expect(po_handler.incoming_size).to eq v
         end
       end
     end
+    it 'sets storage directory' do
+      po_handler = described_class.new(druid, incoming_version, nil, storage_dir)
+      expect(po_handler.storage_dir).to eq storage_dir
+    end
+  end
+  describe '#create' do
+    let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, storage_dir) }
+    let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{storage_dir})" }
+    let!(:exp_msg) { "#{exp_msg_prefix} added object to db as it did not exist" }
+
+    it 'creates the preserved object and preservation copy' do
+      args = {
+        druid: druid,
+        current_version: incoming_version,
+        size: incoming_size,
+        preservation_policy: PreservationPolicy.default_preservation_policy
+      }
+      args2 = {
+        preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
+        current_version: incoming_version,
+        endpoint: Endpoint.find_by(storage_location: storage_dir),
+        status: Status.default_status
+      }
+
+      allow(PreservedObject).to receive(:create!).with(args).and_call_original
+      allow(PreservationCopy).to receive(:create).with(args2).and_call_original
+      po_handler.create
+      expect(PreservedObject).to have_received(:create!).with(args)
+      expect(PreservationCopy).to have_received(:create).with(args2)
+    end
+    context 'object fails validation' do
+      let(:bad_handler) { described_class.new('abc123', incoming_version, incoming_size, storage_dir) }
+      let(:validation_msg_prefix) { "PreservedObjectHandler(abc123, 6, 9876, spec/fixtures/storage_root01/moab_storage_trunk)" }
+      let(:validation_msg) { "#{validation_msg_prefix} encountered validation error(s): [\"Druid is invalid\"]" }
+
+      it 'logs an error' do
+        allow(Rails.logger).to receive(:log).with(Logger::ERROR, validation_msg)
+        bad_handler.create
+        expect(Rails.logger).to have_received(:log).with(Logger::ERROR, validation_msg)
+      end
+    end
+
+    context 'object already exists' do
+      let!(:exp_msg) { "#{exp_msg_prefix} PreservedObject db object already exists" }
+
+      it 'logs an error' do
+        po_handler.create
+        allow(Rails.logger).to receive(:log).with(Logger::ERROR, exp_msg)
+        po_handler.create
+        expect(Rails.logger).to have_received(:log).with(Logger::ERROR, exp_msg)
+      end
+    end
+    context 'returns' do
+      let!(:result) { po_handler.create }
+
+      it '1 result' do
+        expect(result).to be_an_instance_of Array
+        expect(result.size).to eq 1
+      end
+      it 'CREATED_NEW_OBJECT result' do
+        result_code = result.first.keys.first
+        expect(result_code).to eq PreservedObjectHandler::CREATED_NEW_OBJECT
+        result_msg = result.first.values.first
+        expect(result_msg).to match(Regexp.escape(exp_msg))
+      end
+    end
   end
 
-  describe '#update_or_create' do
-    let!(:default_prez_policy) { PreservationPolicy.find_by(preservation_policy_name: 'default') }
+  describe '#update' do
+    let!(:default_prez_policy) { PreservationPolicy.default_preservation_policy }
 
     context 'logs errors and returns INVALID_ARGUMENTS if ActiveModel::Validations fail' do
       let(:bad_druid) { '666' }
       let(:bad_version) { 'vv666' }
       let(:bad_size) { '-666' }
+      let(:bad_storage_dir) { '' }
 
       context 'returns' do
         let!(:result) do
-          po_handler = described_class.new(bad_druid, bad_version, bad_size)
-          po_handler.update_or_create
+          po_handler = described_class.new(bad_druid, bad_version, bad_size, bad_storage_dir)
+          po_handler.update
         end
 
         it '1 result' do
@@ -71,9 +139,22 @@ RSpec.describe PreservedObjectHandler do
         it 'INVALID_ARGUMENTS' do
           expect(result).to include(a_hash_including(PreservedObjectHandler::INVALID_ARGUMENTS))
         end
+
+        context 'object already exists' do
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{storage_dir})" }
+          let!(:exp_msg) { "#{exp_msg_prefix} PreservedObject db object does not exist" }
+          let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, storage_dir) }
+
+          it 'logs an error' do
+            allow(Rails.logger).to receive(:log).with(Logger::ERROR, exp_msg)
+            po_handler.update
+            expect(Rails.logger).to have_received(:log).with(Logger::ERROR, exp_msg)
+          end
+        end
+
         context 'result message includes' do
           let(:msg) { result.first[PreservedObjectHandler::INVALID_ARGUMENTS] }
-          let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_size})" }
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_size}, #{bad_storage_dir})" }
 
           it "prefix" do
             expect(msg).to match(Regexp.escape("#{exp_msg_prefix} encountered validation error(s): "))
@@ -87,186 +168,250 @@ RSpec.describe PreservedObjectHandler do
           it "size error" do
             expect(msg).to match(/Incoming size must be greater than 0/)
           end
+          it "storage dir error" do
+            expect(msg).to match(/Endpoint can't be blank/)
+          end
         end
       end
       it 'bad druid error is written to Rails log' do
-        po_handler = described_class.new(bad_druid, incoming_version, incoming_size)
-        err_msg = "PreservedObjectHandler(#{bad_druid}, #{incoming_version}, #{incoming_size}) encountered validation error(s): [\"Druid is invalid\"]"
+        po_handler = described_class.new(bad_druid, incoming_version, incoming_size, storage_dir)
+        err_msg = "PreservedObjectHandler(#{bad_druid}, #{incoming_version}, #{incoming_size}, #{storage_dir}) encountered validation error(s): [\"Druid is invalid\"]"
         allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
-        po_handler.update_or_create
+        po_handler.update
         expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
       end
       it 'bad version error is written to Rails log' do
-        po_handler = described_class.new(druid, bad_version, incoming_size)
-        err_msg = "PreservedObjectHandler(#{druid}, #{bad_version}, #{incoming_size}) encountered validation error(s): [\"Incoming version is not a number\"]"
+        po_handler = described_class.new(druid, bad_version, incoming_size, storage_dir)
+        err_msg = "PreservedObjectHandler(#{druid}, #{bad_version}, #{incoming_size}, #{storage_dir}) encountered validation error(s): [\"Incoming version is not a number\"]"
         allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
-        po_handler.update_or_create
+        po_handler.update
         expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
       end
       it 'bad size error is written to Rails log' do
-        po_handler = described_class.new(druid, incoming_version, bad_size)
-        err_msg = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{bad_size}) encountered validation error(s): [\"Incoming size must be greater than 0\"]"
+        po_handler = described_class.new(druid, incoming_version, bad_size, storage_dir)
+        err_msg = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{bad_size}, #{storage_dir}) encountered validation error(s): [\"Incoming size must be greater than 0\"]"
         allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
-        po_handler.update_or_create
+        po_handler.update
+        expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
+      end
+      it 'bad storage directory is written to Rails log' do
+        po_handler = described_class.new(druid, incoming_version, incoming_size, bad_storage_dir)
+        err_msg = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{bad_storage_dir}) encountered validation error(s): [\"Endpoint can't be blank\"]"
+        allow(Rails.logger).to receive(:log).with(Logger::ERROR, err_msg)
+        po_handler.update
         expect(Rails.logger).to have_received(:log).with(Logger::ERROR, err_msg)
       end
     end
 
     context 'druid in db' do
       before do
-        po = PreservedObject.find_by(druid: druid)
-        po.destroy if po
-        PreservedObject.create!(druid: druid, current_version: 2, size: 1, preservation_policy: default_prez_policy)
+        po = PreservedObject.create!(druid: druid, current_version: 2, size: 1, preservation_policy: default_prez_policy)
+        PreservationCopy.create!(
+          preserved_object: po, # TODO: see if we got the preserved object that we expected
+          current_version: po.current_version,
+          endpoint: Endpoint.find_by(storage_location: storage_dir),
+          status: Status.default_status
+        )
       end
-      after do
-        po = PreservedObject.find_by(druid: druid)
-        po.destroy if po
-      end
-      let(:po_handler) { described_class.new(druid, incoming_version, incoming_size) }
+
+      let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, storage_dir) }
       let(:po) { PreservedObject.find_by(druid: druid) }
+      let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
+      let(:pc) { PreservationCopy.find_by(preserved_object: po, endpoint: ep) }
 
       context "incoming and db versions match" do
-        let(:po_handler) { described_class.new(druid, 2, 1) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, 1)" }
-        let(:version_matches_msg) { "#{exp_msg_prefix} incoming version (2) matches db version" }
-        let(:updated_db_timestamp_msg) { "#{exp_msg_prefix} updated db timestamp only" }
+        let(:po_handler) { described_class.new(druid, 2, 1, storage_dir) }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, 1, #{storage_dir})" }
+        let(:version_matches_po_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedObject db version" }
+        let(:version_matches_pc_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservationCopy db version" }
+        let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
+        let(:updated_pc_db_timestamp_msg) { "#{exp_msg_prefix} PreservationCopy updated db timestamp only" }
 
         it "entry version stays the same" do
           expect(po.current_version).to eq 2
-          po_handler.update_or_create
+          expect(pc.current_version).to eq 2
+          po_handler.update
           expect(po.reload.current_version).to eq 2
+          expect(pc.reload.current_version).to eq 2
         end
         it "entry size stays the same" do
           expect(po.size).to eq 1
-          po_handler.update_or_create
+          po_handler.update
           expect(po.reload.size).to eq 1
         end
         it "logs at info level" do
-          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_matches_msg)
-          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_db_timestamp_msg)
-          po_handler.update_or_create
-          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_matches_msg)
-          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_db_timestamp_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_matches_po_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_matches_pc_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+          po_handler.update
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_matches_po_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_matches_pc_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+
         end
         context 'returns' do
-          let!(:results) { po_handler.update_or_create }
+          let!(:results) { po_handler.update }
 
           # results = [result1, result2]
           # result1 = {response_code: msg}
           # result2 = {response_code: msg}
-          it '2 results' do
+          it '4 results' do
             expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 2
+            expect(results.size).to eq 4
           end
-          it 'VERSION_MATCHES result' do
+          it 'PreservedObject VERSION_MATCHES result' do
             result_msg = results.select { |r| r[PreservedObjectHandler::VERSION_MATCHES] }.first.values.first
-            expect(result_msg).to match(Regexp.escape(version_matches_msg))
+            expect(result_msg).to match(Regexp.escape(version_matches_po_msg))
           end
-          it "UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+          it 'PreservationCopy VERSION_MATCHES result' do
+            result_msg = results.select { |r| r[PreservedObjectHandler::VERSION_MATCHES] }.second.values.first
+            expect(result_msg).to match(Regexp.escape(version_matches_pc_msg))
+          end
+          it "PreservedObject UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
             result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.first.values.first
-            expect(result_msg).to match(Regexp.escape(updated_db_timestamp_msg))
+            expect(result_msg).to match(Regexp.escape(updated_po_db_timestamp_msg))
+          end
+          it "PreservationCopy UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+            result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.second.values.first
+            expect(result_msg).to match(Regexp.escape(updated_pc_db_timestamp_msg))
           end
         end
       end
-
       context 'incoming version newer than db version' do
-        let(:po_handler) { described_class.new(druid, incoming_version, incoming_size) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})" }
-        let(:version_gt_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than db version" }
-        let(:updated_db_msg) { "#{exp_msg_prefix} db object updated" }
+        let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, storage_dir) }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{storage_dir})" }
+        let(:version_gt_po_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedObject db version" }
+        let(:version_gt_pc_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservationCopy db version" }
+
+        let(:updated_po_db_msg) { "#{exp_msg_prefix} PreservedObject db object updated" }
+        let(:updated_pc_db_msg) { "#{exp_msg_prefix} PreservationCopy db object updated" }
 
         it "updates entry with incoming version" do
           expect(po.current_version).to eq 2
-          po_handler.update_or_create
+          expect(pc.current_version).to eq 2
+          po_handler.update
           expect(po.reload.current_version).to eq incoming_version
+          expect(pc.reload.current_version).to eq incoming_version
         end
         it 'updates entry with size if included' do
           expect(po.size).to eq 1
-          po_handler.update_or_create
+          po_handler.update
           expect(po.reload.size).to eq incoming_size
         end
         it 'retains old size if incoming size is nil' do
           expect(po.size).to eq 1
-          po_handler = described_class.new(druid, incoming_version, nil)
-          po_handler.update_or_create
+          po_handler = described_class.new(druid, incoming_version, nil, storage_dir)
+          po_handler.update
           expect(po.reload.size).to eq 1
         end
         it "logs at info level" do
-          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_msg)
-          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_db_msg)
-          po_handler.update_or_create
-          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_gt_msg)
-          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_db_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_po_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_pc_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_po_db_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_pc_db_msg)
+          po_handler.update
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_gt_po_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_gt_pc_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_po_db_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_pc_db_msg)
+
         end
         context 'returns' do
-          let!(:results) { po_handler.update_or_create }
+          let!(:results) { po_handler.update }
 
           # results = [result1, result2]
           # result1 = {response_code: msg}
           # result2 = {response_code: msg}
-          it '2 results' do
+          it '4 results' do
             expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 2
+            expect(results.size).to eq 4
           end
-          it 'ARG_VERSION_GREATER_THAN_DB_OBJECT result' do
+          it 'PreservedObject ARG_VERSION_GREATER_THAN_DB_OBJECT result' do
             result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT] }.first.values.first
-            expect(result_msg).to match(Regexp.escape(version_gt_msg))
+            expect(result_msg).to match(Regexp.escape(version_gt_po_msg))
           end
-          it "UPDATED_DB_OBJECT result" do
+          it 'PreservationCopy ARG_VERSION_GREATER_THAN_DB_OBJECT result' do
+            result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT] }.second.values.first
+            expect(result_msg).to match(Regexp.escape(version_gt_pc_msg))
+          end
+          it "PreservedObject UPDATED_DB_OBJECT result" do
             result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT] }.first.values.first
-            expect(result_msg).to match(Regexp.escape(updated_db_msg))
+            expect(result_msg).to match(Regexp.escape(updated_po_db_msg))
+          end
+          it "PreservationCopy UPDATED_DB_OBJECT result" do
+            result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT] }.second.values.first
+            expect(result_msg).to match(Regexp.escape(updated_pc_db_msg))
           end
         end
       end
 
       context 'incoming version older than db version' do
-        let(:po_handler) { described_class.new(druid, 1, 666) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, 666)" }
-        let(:version_less_than_msg) { "#{exp_msg_prefix} incoming version (1) less than db version; ERROR!" }
-        let(:updated_db_timestamp_msg) { "#{exp_msg_prefix} updated db timestamp only" }
+        let(:po_handler) { described_class.new(druid, 1, 666, storage_dir) }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, 666, #{storage_dir})" }
+        let(:version_less_than_po_msg) { "#{exp_msg_prefix} incoming version (1) less than PreservedObject db version; ERROR!" }
+        let(:version_less_than_pc_msg) { "#{exp_msg_prefix} incoming version (1) less than PreservationCopy db version; ERROR!" }
+        let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
+        let(:updated_pc_db_timestamp_msg) { "#{exp_msg_prefix} PreservationCopy updated db timestamp only" }
 
         it "entry version stays the same" do
           expect(po.current_version).to eq 2
-          po_handler.update_or_create
+          expect(pc.current_version).to eq 2
+          po_handler.update
           expect(po.reload.current_version).to eq 2
+          expect(pc.reload.current_version).to eq 2
         end
         it "entry size stays the same" do
           expect(po.size).to eq 1
-          po_handler.update_or_create
+          po_handler.update
           expect(po.reload.size).to eq 1
         end
         it "logs at error level" do
-          allow(Rails.logger).to receive(:log).with(Logger::ERROR, version_less_than_msg)
-          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_db_timestamp_msg)
-          po_handler.update_or_create
-          expect(Rails.logger).to have_received(:log).with(Logger::ERROR, version_less_than_msg)
-          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_db_timestamp_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::ERROR, version_less_than_po_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::ERROR, version_less_than_pc_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+
+          po_handler.update
+          expect(Rails.logger).to have_received(:log).with(Logger::ERROR, version_less_than_po_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::ERROR, version_less_than_pc_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+
         end
         context 'returns' do
-          let!(:results) { po_handler.update_or_create }
+          let!(:results) { po_handler.update }
 
           # results = [result1, result2]
           # result1 = {response_code: msg}
           # result2 = {response_code: msg}
-          it '2 results' do
+          it '4 results' do
             expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 2
+            expect(results.size).to eq 4
           end
-          it 'ARG_VERSION_LESS_THAN_DB_OBJECT result' do
+          it 'PreservedObject ARG_VERSION_LESS_THAN_DB_OBJECT result' do
             result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT] }.first.values.first
-            expect(result_msg).to match(Regexp.escape(version_less_than_msg))
+            expect(result_msg).to match(Regexp.escape(version_less_than_po_msg))
+          end
+          it 'PreservationCopy ARG_VERSION_LESS_THAN_DB_OBJECT result' do
+            result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT] }.second.values.first
+            expect(result_msg).to match(Regexp.escape(version_less_than_pc_msg))
           end
           # FIXME: do we want to update timestamp if we found an error (ARG_VERSION_LESS_THAN_DB_OBJECT)
-          it "UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+          it "PreservedObject UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
             result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.first.values.first
-            expect(result_msg).to match(Regexp.escape(updated_db_timestamp_msg))
+            expect(result_msg).to match(Regexp.escape(updated_po_db_timestamp_msg))
+          end
+          it "PreservationCopy UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+            result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.second.values.first
+            expect(result_msg).to match(Regexp.escape(updated_pc_db_timestamp_msg))
           end
         end
       end
-
       context 'db update error' do
         context 'ActiveRecordError' do
-          let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})" }
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{storage_dir})" }
           let(:db_update_failed_prefix) { "#{exp_msg_prefix} db update failed" }
           let(:results) do
             allow(Rails.logger).to receive(:log)
@@ -281,7 +426,7 @@ RSpec.describe PreservedObjectHandler do
             allow(po).to receive(:changed?).and_return(true)
             allow(po).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
             allow(po).to receive(:destroy) # for after() cleanup calls
-            po_handler.update_or_create
+            po_handler.update
           end
 
           it 'DB_UPDATED_FAILED error' do
@@ -302,78 +447,47 @@ RSpec.describe PreservedObjectHandler do
           end
         end
       end
-
-      it 'calls PreservedObject.save if the existing record is altered' do
+      it 'calls PreservedObject.save and PreservationCopy.save if the existing record is altered' do
         po = instance_double(PreservedObject)
+        pc = instance_double(PreservationCopy)
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:current_version=).with(incoming_version)
         allow(po).to receive(:size=).with(incoming_size)
         allow(po).to receive(:changed?).and_return(true)
         allow(po).to receive(:save)
-        po_handler.update_or_create
+        allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:current_version).and_return(1)
+        allow(pc).to receive(:current_version=).with(incoming_version)
+        allow(pc).to receive(:endpoint).with(ep)
+        allow(pc).to receive(:changed?).and_return(true)
+        allow(pc).to receive(:save)
+        po_handler.update
         expect(po).to have_received(:save)
-
-        allow(po).to receive(:destroy)
+        expect(pc).to have_received(:save)
       end
-      it 'calls PreservedObject.touch if the existing record is NOT altered' do
-        po_handler = described_class.new(druid, 1, 1)
+      it 'calls PreservedObject.touch and PreservationCopy.touch if the existing record is NOT altered' do
+        po_handler = described_class.new(druid, 1, 1, storage_dir)
         po = instance_double(PreservedObject)
+        pc = instance_double(PreservationCopy)
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:changed?).and_return(false)
         allow(po).to receive(:touch)
-        po_handler.update_or_create
+        allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:current_version).and_return(1)
+        allow(pc).to receive(:endpoint).with(ep)
+        allow(pc).to receive(:changed?).and_return(false)
+        allow(pc).to receive(:touch)
+        po_handler.update
         expect(po).to have_received(:touch)
-
-        allow(po).to receive(:destroy)
+        expect(pc).to have_received(:touch)
       end
       it 'logs a debug message' do
         msg = "update #{druid} called and object exists"
         allow(Rails.logger).to receive(:debug)
-        po_handler.update_or_create
+        po_handler.update
         expect(Rails.logger).to have_received(:debug).with(msg)
-      end
-    end
-
-    context 'druid not in db (yet)' do
-      after do
-        po = PreservedObject.find_by(druid: druid)
-        po.destroy if po
-      end
-      let(:po_handler) { described_class.new(druid, incoming_version, incoming_size) }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size})" }
-      let(:exp_msg) { "#{exp_msg_prefix} added object to db as it did not exist" }
-
-      it 'creates the object' do
-        args = {
-          druid: druid,
-          current_version: incoming_version,
-          size: incoming_size,
-          preservation_policy: an_instance_of(PreservationPolicy)
-        }
-        allow(PreservedObject).to receive(:create).with(args)
-        po_handler.update_or_create
-        expect(PreservedObject).to have_received(:create).with(args)
-      end
-      it 'logs a warning' do
-        allow(Rails.logger).to receive(:log).with(Logger::WARN, exp_msg)
-        po_handler.update_or_create
-        expect(Rails.logger).to have_received(:log).with(Logger::WARN, exp_msg)
-      end
-      context 'returns' do
-        let!(:result) { po_handler.update_or_create }
-
-        it '1 result' do
-          expect(result).to be_an_instance_of Array
-          expect(result.size).to eq 1
-        end
-        it 'CREATED_NEW_OBJECT result' do
-          result_code = result.first.keys.first
-          expect(result_code).to eq PreservedObjectHandler::CREATED_NEW_OBJECT
-          result_msg = result.first.values.first
-          expect(result_msg).to match(Regexp.escape(exp_msg))
-        end
       end
     end
   end


### PR DESCRIPTION
* remaining TODO
  * [x] rebase on current master
  * [x] make sure all status codes are being used
  * [x] make sure status code messages say the right thing
  * [x] make sure status codes correspond to right logger severity
  * [x] fix `MoabToCatalog.check_moab_to_catalog_existence` to do the right po_handler calls
  * [ ] some new uses of `%{addl}` should maybe be `%{obj_class_name}` (actually, this prob requires assuming `addl` will be a hash w/ named params, since var name `addl` is expected by helper methods `result_code_msg` and `result_hash`) ticket #196 
  * [x] rubocop cleanup - 2 rubocop errors left, change ```to received``` to  ```to have_received```
  * [x] refactoring?  DRY things up?
  * [x] unit tests for `if invalid?` branch in `#update` and `#create` methods of PreservedObjectHandler
  * [ ] `#create` should prob trap `ActiveRecord::ActiveRecordError` for status code return like `#update` ticket #198
    * [ ] and corresponding unit test ticket #198 
  * [ ] add corresponding test for ```druid expected to exist in catalog but was not found``` in ```moab_to_catalog.rb```  ticket #197
  * [ ] test for `MoabToCatalog.check_moab_to_catalog_existence` `expect_to_create` flag


closes #183
closes #157
closes #131
closes #180