### PR TITLE
make preservation_policy_name unique and indexed

### DIFF
--- a/app/models/preservation_policy.rb
+++ b/app/models/preservation_policy.rb
@@ -5,7 +5,7 @@ class PreservationPolicy < ApplicationRecord
   has_many :preserved_objects, dependent: :restrict_with_exception
   has_and_belongs_to_many :endpoints
 
-  validates :preservation_policy_name, presence: true
+  validates :preservation_policy_name, presence: true, uniqueness: true
   validates :archive_ttl, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :fixity_ttl, presence: true, numericality: { only_integer: true, greater_than: 0 }
 

--- a/db/migrate/20171011142253_add_index_to_preservation_policies.rb
+++ b/db/migrate/20171011142253_add_index_to_preservation_policies.rb
@@ -1,0 +1,5 @@
+class AddIndexToPreservationPolicies < ActiveRecord::Migration[5.1]
+  def change
+    add_index :preservation_policies, :preservation_policy_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171006193131) do
+ActiveRecord::Schema.define(version: 20171011142253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20171006193131) do
     t.string "preservation_policy_name", null: false
     t.integer "archive_ttl", null: false
     t.integer "fixity_ttl", null: false
+    t.index ["preservation_policy_name"], name: "index_preservation_policies_on_preservation_policy_name", unique: true
   end
 
   create_table "preserved_objects", force: :cascade do |t|

--- a/spec/models/preservation_copy_spec.rb
+++ b/spec/models/preservation_copy_spec.rb
@@ -11,11 +11,7 @@ RSpec.describe PreservationCopy, type: :model do
       recovery_cost: '1'
     )
   end
-  let!(:preservation_policy) do
-    PreservationPolicy.create!(preservation_policy_name: 'default',
-                               archive_ttl: 604_800,
-                               fixity_ttl: 604_800)
-  end
+  let!(:preservation_policy) { PreservationPolicy.find_by(preservation_policy_name: 'default') }
 
   let!(:preserved_object) do
     PreservedObject.create!(

--- a/spec/models/preservation_policy_spec.rb
+++ b/spec/models/preservation_policy_spec.rb
@@ -2,14 +2,28 @@ require 'rails_helper'
 
 RSpec.describe PreservationPolicy, type: :model do
   it 'is valid with valid attributes' do
-    preservation_policy = PreservationPolicy.create!(preservation_policy_name: 'default',
-                                                     archive_ttl: 604_800,
-                                                     fixity_ttl: 604_800)
+    preservation_policy = PreservationPolicy.find_by(preservation_policy_name: 'default')
     expect(preservation_policy).to be_valid
   end
 
   it 'is not valid without valid attributes' do
     expect(PreservationPolicy.new).not_to be_valid
+  end
+
+  it 'enforces unique constraint on preservation_policy_name (model level)' do
+    exp_err_msg = 'Validation failed: Preservation policy name has already been taken'
+    expect do
+      PreservationPolicy.create!(preservation_policy_name: 'default',
+                                 archive_ttl: 604_800,
+                                 fixity_ttl: 604_800)
+    end.to raise_error(ActiveRecord::RecordInvalid, exp_err_msg)
+  end
+
+  it 'enforces unique constraint on preservation_policy_name (db level)' do
+    dup_preservation_policy = PreservationPolicy.new(preservation_policy_name: 'default',
+                                                     archive_ttl: 604_800,
+                                                     fixity_ttl: 604_800)
+    expect { dup_preservation_policy.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
   it { is_expected.to have_many(:preserved_objects) }

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -1,11 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PreservedObject, type: :model do
-  let!(:preservation_policy) do
-    PreservationPolicy.create!(preservation_policy_name: 'default',
-                               archive_ttl: 604_800,
-                               fixity_ttl: 604_800)
-  end
+  let!(:preservation_policy) { PreservationPolicy.find_by(preservation_policy_name: 'default') }
 
   let(:required_attributes) do
     {

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -51,11 +51,7 @@ RSpec.describe PreservedObjectHandler do
   end
 
   describe '#update_or_create' do
-    let!(:default_prez_policy) do
-      PreservationPolicy.create!(preservation_policy_name: 'default',
-                                 archive_ttl: 604_800,
-                                 fixity_ttl: 604_800)
-    end
+    let!(:default_prez_policy) { PreservationPolicy.find_by(preservation_policy_name: 'default') }
 
     context 'logs errors and returns INVALID_ARGUMENTS if ActiveModel::Validations fail' do
       let(:bad_druid) { '666' }


### PR DESCRIPTION
Using `default` as the same `preservation_policy_name` across different specs was making rspec try to create more than one `preservation_policy` object whose name was `default`, triggering the uniqueness validation, so my workaround was to make the name unique to each spec.

Resolve #137 