### PR TITLE
change druid regex to use druid-tools

### DIFF
--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -6,7 +6,7 @@
 class PreservedObject < ApplicationRecord
   belongs_to :preservation_policy
   has_many :preservation_copies, dependent: :restrict_with_exception
-  validates :druid, presence: true, uniqueness: true, format: { with: /\A[a-z]{2}\d{3}[a-z]{2}\d{4}\z/ }
+  validates :druid, presence: true, uniqueness: true, format: { with: DruidTools::Druid.pattern }
   validates :current_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
   # NOTE: size here is approximate and not used for fixity checking
   validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -30,7 +30,7 @@ class PreservedObjectHandler
   include ActiveModel::Validations
 
   # Note: supplying validations here to allow validation before use, e.g. incoming_version in numeric logic
-  validates :druid, presence: true, format: { with: /\A[a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4}\z/ }
+  validates :druid, presence: true, format: { with: DruidTools::Druid.pattern }
   validates :incoming_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :incoming_size, numericality: { only_integer: true, greater_than: 0 }
 


### PR DESCRIPTION
instead of using ``` /\A[a-z]{2}\d{3}[a-z]{2}\d{4}\z/``` we can use ```DruidTools::Druid.pattern```
connects #133