### PR TITLE
rename MoabToCatalog.check_moab_to_catalog_existence to check_existence

### DIFF
--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -1,7 +1,7 @@
 ##
 # Method that will check the a single moab service disk for the existence of moabs in postgres database
 class MoabToCatalog
-  def self.check_moab_to_catalog_existence(storage_dir, expect_to_create=false)
+  def self.check_existence(storage_dir, expect_to_create=false)
     results = []
     MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
       moab = Moab::StorageObject.new(druid, path)

--- a/lib/benchmarking/moab_to_catalog_testing.rb
+++ b/lib/benchmarking/moab_to_catalog_testing.rb
@@ -36,7 +36,7 @@ Stanford::StorageServices.storage_roots.each do |storage_root|
   time_to_check_existence = Benchmark.realtime do
     # RubyProf.start
     logger.info "Check for output"
-    MoabToCatalog.check_moab_to_catalog_existence(File.join(storage_root, Moab::Config.storage_trunk))
+    MoabToCatalog.check_existence(File.join(storage_root, Moab::Config.storage_trunk))
     # when creating add true parameter, and if updating leave blank
     # @prof = RubyProf.stop
   end

--- a/lib/benchmarking/moab_to_catalog_testing.rb
+++ b/lib/benchmarking/moab_to_catalog_testing.rb
@@ -1,4 +1,4 @@
-# bin/rails runner lib/benchmark/moab_to_catalog_testing.rb
+# bin/rails runner lib/benchmarking/moab_to_catalog_testing.rb
 
 require 'benchmark'
 require 'logger'
@@ -6,10 +6,11 @@ require_relative "../audit/moab_to_catalog.rb"
 require 'ruby-prof'
 
 logger = Logger.new('log/benchmark_moab_to_catalog.log')
-at_exit do # #{pcc_app_home}/current/log/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
-  # File.open "/tmp/MoabtoCatalog_rubyprof_#{Time.now.getlocal}", 'w' do |file|
-  # RubyProf::FlatPrinter.new(@prof).print(file)
-
+at_exit do
+  # prof_log_file_name = "{pcc_app_home}/current/log/MoabtoCatalog_rubyprof_#{Time.now.getlocal}"
+  # prof_log_file_name = "/tmp/MoabtoCatalog_rubyprof_#{Time.now.getlocal}"
+  # File.open prof_log_file_name, 'w' do |file|
+  #   RubyProf::FlatPrinter.new(@prof).print(file)
   # end
   logger.info "Benchmarking stopped at #{Time.now.getlocal}"
 end
@@ -29,15 +30,19 @@ else
   logger.info "at revision #{commit}"
 end
 sleep(10)
-# storage_dir = 'spec/fixtures/storage_root01/moab_storage_trunk'
-# storage_dir = '/services-disk12/sdr2objects'
+
 # this is coming from config/settings.yml and config/initializers
 Stanford::StorageServices.storage_roots.each do |storage_root|
   time_to_check_existence = Benchmark.realtime do
-    # RubyProf.start
     logger.info "Check for output"
-    MoabToCatalog.check_existence(File.join(storage_root, Moab::Config.storage_trunk))
+    # RubyProf.start
     # when creating add true parameter, and if updating leave blank
+    MoabToCatalog.check_existence(File.join(storage_root, Moab::Config.storage_trunk))
+    # TODO: haven't actually tested this, but looks to me like this will only get profiling info for the last
+    # storage root that was checked.  one way to collect for everything would be to use the start/pause/resume
+    # approach described in the RubyProf docs, presumably with a start/pause above this loop, resume/pause in
+    # this loop, and @prof = RubyProf.stop after this loop.
+    # see https://github.com/ruby-prof/ruby-prof#ruby-prof-convenience-api
     # @prof = RubyProf.stop
   end
   logger.info time_to_check_existence.to_s

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -1,12 +1,12 @@
 require_relative "../../../lib/audit/moab_to_catalog.rb"
 RSpec.describe MoabToCatalog do
-  describe ".check_moab_to_catalog_existence" do
+  describe ".check_existence" do
     before do
       PreservationPolicy.seed_from_config
     end
 
     let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
-    let(:subject) { described_class.check_moab_to_catalog_existence(storage_dir) }
+    let(:subject) { described_class.check_existence(storage_dir) }
 
     it "call 'find_moab_paths' with appropriate argument" do
       allow(MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
@@ -65,14 +65,14 @@ RSpec.describe MoabToCatalog do
     end
 
     it "storage directory doesn't exist (misspelling, read write permissions)" do
-      expect { described_class.check_moab_to_catalog_existence('spec/fixtures/moab_strge_root') }.to raise_error(
+      expect { described_class.check_existence('spec/fixtures/moab_strge_root') }.to raise_error(
         SystemCallError, /No such file or directory/
       )
     end
 
     it "storage directory exists but it is empty" do
       storage_dir = 'spec/fixtures/empty'
-      expect(described_class.check_moab_to_catalog_existence(storage_dir)).to eq []
+      expect(described_class.check_existence(storage_dir)).to eq []
     end
 
   end


### PR DESCRIPTION
the first commit does what's described in the associated issue.

the second commit is a handful of small touchups to the script that does performance profiling on `MoabToCatalog.check_existence` (née `check_moab_to_catalog_existence`).  those were pretty easy fixes, so i went ahead and did them while i was there.  hopefully uncontroversial, but if they're distracting, i'm happy to put them in a separate PR with an associated ticket (or to discard them altogether if people think they're a bad idea).  i tested that script a bit, and it seems to still work fine after the changes (though i didn't test the profiling stuff, since that was commented out).

closes #202 