### PR TITLE
moab_to_catalog: get size more efficiently

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,8 @@ Naming/FileName:
     - 'Capfile'
     - 'Gemfile'
 
+# --- Performance ---
+
 # --- Rails ---
 
 Rails/FilePath:
@@ -103,9 +105,9 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Max: 4
 
+# we like 'expect(x).to receive' better than 'have_received'
 RSpec/MessageSpies:
-  Exclude:
-    - 'spec/services/preserved_object_handler_spec.rb' # couldn't figure out a logging test
+  Enabled: false
 
 RSpec/NamedSubject:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.1.5)
-    druid-tools (0.4.1)
+    druid-tools (1.0.0)
     erubi (1.6.1)
     ffi (1.9.18)
     globalid (0.4.0)
@@ -121,8 +121,9 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    moab-versioning (2.1.0)
+    moab-versioning (2.2.0)
       confstruct
+      druid-tools (>= 1.0.0)
       json
       nokogiri
       nokogiri-happymapper

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -5,9 +5,7 @@ class MoabToCatalog
     results = []
     MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
       moab = Moab::StorageObject.new(druid, path)
-      moab_current_version = moab.current_version_id
-      moab_size = Stanford::StorageServices.object_size(druid)
-      po_handler = PreservedObjectHandler.new(druid, moab_current_version, moab_size, storage_dir)
+      po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, storage_dir)
       if PreservedObject.exists?(druid: druid)
         results << po_handler.update
       else

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -13,6 +13,31 @@ RSpec.describe MoabToCatalog do
       subject
       expect(MoabStorageDirectory).to have_received(:find_moab_paths).with(storage_dir)
     end
+
+    it 'gets moab current version from Moab::StorageObject' do
+      moab = instance_double(Moab::StorageObject)
+      allow(moab).to receive(:storage_root=)
+      allow(moab).to receive(:object_pathname).and_return(storage_dir)
+      allow(moab).to receive(:size)
+      expect(moab).to receive(:current_version_id).at_least(1).times
+      allow(Moab::StorageObject).to receive(:new).and_return(moab)
+
+      expect(Moab::StorageServices).not_to receive(:new)
+      subject
+    end
+
+    it 'gets moab size from Moab::StorageObject' do
+      moab = instance_double(Moab::StorageObject)
+      allow(moab).to receive(:storage_root=)
+      allow(moab).to receive(:object_pathname).and_return(storage_dir)
+      allow(moab).to receive(:current_version_id)
+      expect(moab).to receive(:size).at_least(1).times
+      allow(Moab::StorageObject).to receive(:new).and_return(moab)
+
+      expect(Moab::StorageServices).not_to receive(:new)
+      subject
+    end
+
     context "determine create or update method with expected values" do
       let(:expected_argument_list) do
         [


### PR DESCRIPTION
Use more efficient way to get the size of a moab object directly from Moab::StorageObject.

Resolves #206