### PR TITLE
Remove inline test fixtures

### DIFF
--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -29,9 +29,6 @@ RSpec.shared_context "fixture moabs in db" do
 end
 
 def load_fixture_moabs
-  pp_default = PreservationPolicy.default_preservation_policy
-  status_ok_id = Status.find_by(status_text: 'ok').id
-
   @moab_storage_dirs.each do |storage_dir|
     MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, _path, _path_match_data|
       version = Stanford::StorageServices.current_version(druid)
@@ -39,11 +36,11 @@ def load_fixture_moabs
       po = PreservedObject.create(druid: druid,
                                   current_version: version,
                                   size: size,
-                                  preservation_policy: pp_default)
+                                  preservation_policy: PreservationPolicy.default_preservation_policy)
       PreservationCopy.create(preserved_object_id: po.id,
                               endpoint_id: @storage_dir_to_endpoint_id[storage_dir],
                               current_version: version,
-                              status_id: status_ok_id)
+                              status_id: Status.default_status.id)
     end
   end
 end

--- a/spec/models/endpoint_type_spec.rb
+++ b/spec/models/endpoint_type_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe EndpointType, type: :model do
   let(:test_type_name) { 'unit_test_nfs' }
-  let!(:endpoint_type) { EndpointType.create!(type_name: test_type_name, endpoint_class: 'online') }
 
   it 'is valid with valid attributes' do
+    endpoint_type = EndpointType.create!(type_name: test_type_name, endpoint_class: 'online')
     expect(endpoint_type).to be_valid
   end
 
@@ -14,6 +14,7 @@ RSpec.describe EndpointType, type: :model do
 
   it 'enforces unique constraint on type_name' do
     expect do
+      EndpointType.create!(type_name: test_type_name, endpoint_class: 'online')
       EndpointType.create!(type_name: test_type_name, endpoint_class: 'online')
     end.to raise_error(ActiveRecord::RecordInvalid)
   end
@@ -30,8 +31,8 @@ RSpec.describe EndpointType, type: :model do
     it 'does not re-create records that already exist' do
       # run it a second time
       EndpointType.seed_from_config
-      # sort so we can avoid comparing via include, and see that it has only/exactly the two expected elements
-      expect(EndpointType.pluck(:type_name).sort).to eq %w[online_nfs unit_test_nfs]
+      # sort so we can avoid comparing via include, and see that it has only/exactly the expected elements
+      expect(EndpointType.pluck(:type_name).sort).to eq %w[online_nfs]
     end
 
     it 'adds new records if there are additions to Settings since the last run' do

--- a/spec/models/preservation_copy_spec.rb
+++ b/spec/models/preservation_copy_spec.rb
@@ -1,24 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe PreservationCopy, type: :model do
-  let!(:endpoint_type) { EndpointType.create(type_name: 'aws', endpoint_class: 'archive') }
-  let!(:endpoint) do
-    Endpoint.create(
-      endpoint_name: 'aws',
-      endpoint_type_id: endpoint_type.id,
-      endpoint_node: 'sul-sdr',
-      storage_location: '/storage',
-      recovery_cost: '1'
-    )
-  end
-  let!(:preservation_policy) { PreservationPolicy.find_by(preservation_policy_name: 'default') }
-
+  let!(:endpoint) { Endpoint.first }
   let!(:preserved_object) do
-    PreservedObject.create!(
-      druid: 'ab123cd4567', current_version: 1, preservation_policy_id: preservation_policy.id, size: 1
-    )
+    policy_id = PreservationPolicy.default_preservation_policy.id
+    PreservedObject.create!(druid: 'ab123cd4567', current_version: 1, preservation_policy_id: policy_id, size: 1)
   end
-  let!(:status) { Status.find_by(status_text: 'ok') }
+  let!(:status) { Status.default_status }
   let!(:preservation_copy) do
     PreservationCopy.create!(
       preserved_object_id: preserved_object.id,

--- a/spec/models/preservation_policy_spec.rb
+++ b/spec/models/preservation_policy_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe PreservationPolicy, type: :model do
     exp_err_msg = 'Validation failed: Preservation policy name has already been taken'
     expect do
       PreservationPolicy.create!(preservation_policy_name: 'default',
-                                 archive_ttl: 604_800,
-                                 fixity_ttl: 604_800)
+                                 archive_ttl: 666,
+                                 fixity_ttl: 666)
     end.to raise_error(ActiveRecord::RecordInvalid, exp_err_msg)
   end
 
   it 'enforces unique constraint on preservation_policy_name (db level)' do
     dup_preservation_policy = PreservationPolicy.new(preservation_policy_name: 'default',
-                                                     archive_ttl: 604_800,
-                                                     fixity_ttl: 604_800)
+                                                     archive_ttl: 666,
+                                                     fixity_ttl: 666)
     expect { dup_preservation_policy.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
@@ -48,7 +48,7 @@ RSpec.describe PreservationPolicy, type: :model do
     it 'adds new records if there are additions to Settings since the last run' do
       # db already seeded
       archive_pres_policy_setting = Config::Options.new(
-        archive_policy: Config::Options.new(archive_ttl: 604_800, fixity_ttl: 604_800)
+        archive_policy: Config::Options.new(archive_ttl: 666, fixity_ttl: 666)
       )
       allow(Settings.preservation_policies).to receive(:policy_definitions).and_return(archive_pres_policy_setting)
       PreservationPolicy.seed_from_config

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PreservedObject, type: :model do
-  let!(:preservation_policy) { PreservationPolicy.find_by(preservation_policy_name: 'default') }
+  let!(:preservation_policy) { PreservationPolicy.default_preservation_policy }
 
   let(:required_attributes) do
     {

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Status, type: :model do
-  let!(:status) { Status.find_by(status_text: 'ok') }
+  let!(:status) { Status.default_status }
 
   it 'is valid with valid attributes' do
     expect(status).to be_valid


### PR DESCRIPTION
for endpoint_type_spec, the tests seemed clearer to me when I put the EndpointType.create in the 3 tests relying on it, rather than the "let" statement.

I believe this resolves #126 (replace inline created test fixtures with seeded objects) as much as is appropriate.

Also resolves #139 - we don't need to use 604800 as the ttl value in our specs, and that is the only place (besides settings.yml) where that value is used.