### PR TITLE
Get settings for fixture storage roots out of the way of shared_configs

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,10 +12,13 @@ endpoints:
 
 moab:
   # this is a list of named storage roots.  the names are used to seed the endpoints table.
-  storage_roots:
+  # any named storage roots added in the root settings.yml will always be inherited by env specific configs, even
+  # if they aren't listed directly in the settings/*.yml file for an environment. so list storage roots directly in
+  # the relevant settings file for the env, including for vanilla unit test env.
+  # storage_roots:
     # name: '/location/on/disk'  # e.g.
-    fixture_sr1: 'spec/fixtures/storage_root01'
-    fixture_sr2: 'spec/fixtures/storage_root02'
+    # fixture_sr1: 'spec/fixtures/storage_root01'
+    # fixture_sr2: 'spec/fixtures/storage_root02'
   # storage_trunk is the name of the directory under a storage_root which contains
   # the druid trees:  e.g. 'spec/fixtures/moab_storage_root' will contain all the druid
   # trees for this configuration.  if there are multiple storage roots, each will have

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,7 @@
+moab:
+  # this is a list of named storage roots.  the names are used to seed the endpoints table.
+  storage_roots:
+    # name: '/location/on/disk'  # e.g.
+    fixture_sr1: 'spec/fixtures/storage_root01'
+    fixture_sr2: 'spec/fixtures/storage_root02'
+  

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,6 @@
+moab:
+  # this is a list of named storage roots.  the names are used to seed the endpoints table.
+  storage_roots:
+    # name: '/location/on/disk'  # e.g.
+    fixture_sr1: 'spec/fixtures/storage_root01'
+    fixture_sr2: 'spec/fixtures/storage_root02'


### PR DESCRIPTION
Fixes #217 

This seems like a bit of a hack but it does get the fixtures out of the settings object -- I'm open to discussing better approaches.