### PR TITLE
Require rails_helper so we can run moab_to_catalog_spec on its own.

### DIFF
--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require_relative "../../../lib/audit/moab_to_catalog.rb"
 
 RSpec.describe MoabToCatalog do


### PR DESCRIPTION
Without requiring rails_helper, I'm unable to run the moab_to_catalog tests on their own (i.e. without running the entire test suite). This is just a convenience PR.