### PR TITLE
turn #update into #confirm_version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,7 +103,7 @@ RSpec/ExampleLength:
   Max: 50
 
 RSpec/MultipleExpectations:
-  Max: 4
+  Max: 5
 
 # we like 'expect(x).to receive' better than 'have_received'
 RSpec/MessageSpies:

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -10,7 +10,7 @@ class MoabToCatalog
       moab = Moab::StorageObject.new(druid, path)
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, storage_dir)
       if PreservedObject.exists?(druid: druid)
-        results << po_handler.update
+        results << po_handler.confirm_version
       else
         Rails.logger.error "druid: #{druid} expected to exist in catalog but was not found"
         results << po_handler.create if expect_to_create

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe MoabToCatalog do
       subject
     end
 
-    context "(calls create or update)" do
+    context "(calls create or confirm_version)" do
       let(:expected_argument_list) do
         [
           { druid: 'bj102hs9687', storage_root_current_version: 3 },
@@ -83,10 +83,10 @@ RSpec.describe MoabToCatalog do
         end
       end
 
-      it "calls #update if object exists" do
+      it "calls #confirm_version if object exists" do
         expected_argument_list.each do |arg_hash|
           expect(PreservedObject).to receive(:exists?).with(druid: arg_hash[:druid]).and_return(true)
-          expect(arg_hash[:po_handler]).to receive(:update)
+          expect(arg_hash[:po_handler]).to receive(:confirm_version)
         end
         subject
       end


### PR DESCRIPTION
helper method `#update_per_version_comparison` becomes `#confirm_version_on_db_object` (paired w/ @tingulfsen)

connects to #221 

Note that travis fails on rubocop, and it is due to WIP on update_version work.