### PR TITLE
split POH #update into #update_version and #confirm_version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,7 +103,7 @@ RSpec/ExampleLength:
   Max: 50
 
 RSpec/MultipleExpectations:
-  Max: 4
+  Max: 5
 
 # we like 'expect(x).to receive' better than 'have_received'
 RSpec/MessageSpies:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,7 +55,8 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 200
+  Exclude:
+    - 'app/services/preserved_object_handler.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -70,6 +71,8 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Max: 25
+  Exclude:
+    - 'app/services/preserved_object_handler.rb'
 
 # --- Naming ---
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -124,7 +124,6 @@ class PreservedObjectHandler
             update_preserved_object(pres_object, incoming_version, incoming_size)
             update_db_object(pres_object, results)
           end
-          # TODO: comparable else for the pres object version mismatch
         else
           results << result_hash(UNEXPECTED_VERSION, 'PreservationCopy')
           results << version_comparison_results(pres_copy)

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -72,6 +72,8 @@ class PreservedObjectHandler
                                 endpoint: endpoint,
                                 status: status)
         results << result_hash(CREATED_NEW_OBJECT)
+      rescue ActiveRecord::RecordNotFound => e
+        results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)
       rescue ActiveRecord::ActiveRecordError => e
         results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
       end
@@ -92,6 +94,8 @@ class PreservedObjectHandler
         results << confirm_version_on_db_object(po_db_object)
         pc_db_object = PreservationCopy.find_by!(preserved_object: po_db_object, endpoint: endpoint)
         results << confirm_version_on_db_object(pc_db_object)
+      rescue ActiveRecord::RecordNotFound => e
+        results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)
       rescue ActiveRecord::ActiveRecordError => e
         results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
       end
@@ -127,6 +131,8 @@ class PreservedObjectHandler
           results << version_comparison_results(pres_object)
           # FIXME: TODO: should it update existence check timestamps/status?
         end
+      rescue ActiveRecord::RecordNotFound => e
+        results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)
       rescue ActiveRecord::ActiveRecordError => e
         results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
       end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -67,10 +67,10 @@ class PreservedObjectHandler
                                      size: incoming_size,
                                      preservation_policy: pp_default)
         status = Status.default_status
-        PreservationCopy.create(preserved_object: po,
-                                current_version: incoming_version,
-                                endpoint: endpoint,
-                                status: status)
+        PreservationCopy.create!(preserved_object: po,
+                                 current_version: incoming_version,
+                                 endpoint: endpoint,
+                                 status: status)
         results << result_hash(CREATED_NEW_OBJECT)
       rescue ActiveRecord::RecordNotFound => e
         results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -10,7 +10,7 @@ class MoabToCatalog
       moab = Moab::StorageObject.new(druid, path)
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, storage_dir)
       if PreservedObject.exists?(druid: druid)
-        results << po_handler.update
+        results << po_handler.confirm_version
       else
         Rails.logger.error "druid: #{druid} expected to exist in catalog but was not found"
         results << po_handler.create if expect_to_create

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe MoabToCatalog do
       subject
     end
 
-    context "(calls create or update)" do
+    context "(calls create or confirm_version)" do
       let(:expected_argument_list) do
         [
           { druid: 'bj102hs9687', storage_root_current_version: 3 },
@@ -83,10 +83,10 @@ RSpec.describe MoabToCatalog do
         end
       end
 
-      it "calls #update if object exists" do
+      it "calls #confirm_version if object exists" do
         expected_argument_list.each do |arg_hash|
           expect(PreservedObject).to receive(:exists?).with(druid: arg_hash[:druid]).and_return(true)
-          expect(arg_hash[:po_handler]).to receive(:update)
+          expect(arg_hash[:po_handler]).to receive(:confirm_version)
         end
         subject
       end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -354,12 +354,12 @@ RSpec.describe PreservedObjectHandler do
       context 'incoming version newer than PreservationCopy but not PreservedObject' do
         context 'PreservedObject version same' do
           it 'does something' do
-            skip('write this spec')
+            skip('write this spec; we need to figure out the desired behavior.')
           end
         end
         context 'PreservedObject version greater' do
           it 'does something' do
-            skip('write this spec')
+            skip('write this spec; we need to figure out the desired behavior.')
           end
         end
       end
@@ -367,12 +367,12 @@ RSpec.describe PreservedObjectHandler do
       context 'incoming version newer than PreservedObject but not PreservationCopy' do
         context 'PreservationCopy version same' do
           it 'does something' do
-            skip('write this spec')
+            skip('write this spec; we need to figure out the desired behavior.')
           end
         end
         context 'PreservationCopy version greater' do
           it 'does something' do
-            skip('write this spec')
+            skip('write this spec; we need to figure out the desired behavior.')
           end
         end
       end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -151,10 +151,10 @@ RSpec.describe PreservedObjectHandler do
       }
 
       allow(PreservedObject).to receive(:create!).with(args).and_call_original
-      allow(PreservationCopy).to receive(:create).with(args2).and_call_original
+      allow(PreservationCopy).to receive(:create!).with(args2).and_call_original
       po_handler.create
       expect(PreservedObject).to have_received(:create!).with(args)
-      expect(PreservationCopy).to have_received(:create).with(args2)
+      expect(PreservationCopy).to have_received(:create!).with(args2)
     end
 
     it_behaves_like 'attributes validated', :create

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe PreservedObjectHandler do
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' } # we are just going to assume the first rails storage root
+  let!(:default_prez_policy) { PreservationPolicy.default_preservation_policy }
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
   let(:pc) { PreservationCopy.find_by(preserved_object: po, endpoint: ep) }
@@ -214,6 +215,405 @@ RSpec.describe PreservedObjectHandler do
         expect(result_code).to eq PreservedObjectHandler::CREATED_NEW_OBJECT
         result_msg = result.first.values.first
         expect(result_msg).to match(Regexp.escape(exp_msg))
+      end
+    end
+  end
+
+  describe '#update_version' do
+    it_behaves_like 'attributes validated', :update_version
+
+    context 'PreservedObject does not exist' do
+      let!(:exp_msg) { "#{exp_msg_prefix} PreservedObject db object does not exist" }
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:log).with(Logger::ERROR, exp_msg)
+        po_handler.update_version
+      end
+
+      context 'returns' do
+        let!(:result) { po_handler.update_version }
+
+        it '1 result' do
+          expect(result).to be_an_instance_of Array
+          expect(result.size).to eq 1
+        end
+        it 'OBJECT_DOES_NOT_EXIST result' do
+          result_code = result.first.keys.first
+          expect(result_code).to eq PreservedObjectHandler::OBJECT_DOES_NOT_EXIST
+          result_msg = result.first.values.first
+          expect(result_msg).to match(Regexp.escape(exp_msg))
+          po_handler.update_version
+        end
+      end
+    end
+
+    context 'PreservationCopy does not exist' do
+      before do
+        PreservedObject.create!(druid: druid, current_version: 2, size: 1, preservation_policy: default_prez_policy)
+      end
+      let!(:exp_msg) { "#{exp_msg_prefix} PreservationCopy db object does not exist" }
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:log).with(Logger::ERROR, exp_msg)
+        po_handler.update_version
+      end
+
+      context 'returns' do
+        let!(:result) { po_handler.update_version }
+
+        it '1 result' do
+          expect(result).to be_an_instance_of Array
+          expect(result.size).to eq 1
+        end
+        it 'OBJECT_DOES_NOT_EXIST result' do
+          result_code = result.first.keys.first
+          expect(result_code).to eq PreservedObjectHandler::OBJECT_DOES_NOT_EXIST
+          result_msg = result.first.values.first
+          expect(result_msg).to match(Regexp.escape(exp_msg))
+          po_handler.update_version
+        end
+      end
+    end
+
+    context 'in Catalog' do
+      before do
+        po = PreservedObject.create!(druid: druid, current_version: 2, size: 1, preservation_policy: default_prez_policy)
+        PreservationCopy.create!(
+          preserved_object: po, # TODO: see if we got the preserved object that we expected
+          current_version: po.current_version,
+          endpoint: ep,
+          status: Status.unexpected_version
+        )
+      end
+
+      context 'incoming version newer than db version (happy path)' do
+        let(:version_gt_pc_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservationCopy db version" }
+        let(:version_gt_po_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedObject db version" }
+        let(:updated_pc_db_msg) { "#{exp_msg_prefix} PreservationCopy db object updated" }
+        let(:updated_po_db_msg) { "#{exp_msg_prefix} PreservedObject db object updated" }
+        let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservationCopy status changed from")) }
+
+        it "updates entries with incoming version" do
+          expect(pc.current_version).to eq 2
+          expect(po.current_version).to eq 2
+          po_handler.update_version
+          expect(pc.reload.current_version).to eq incoming_version
+          expect(po.reload.current_version).to eq incoming_version
+        end
+        it 'updates entries with size if included' do
+          expect(po.size).to eq 1
+          po_handler.update_version
+          expect(po.reload.size).to eq incoming_size
+        end
+        it 'retains old size if incoming size is nil' do
+          expect(po.size).to eq 1
+          po_handler = described_class.new(druid, incoming_version, nil, storage_dir)
+          po_handler.update_version
+          expect(po.reload.size).to eq 1
+        end
+        it 'updates status of PreservationCopy to "ok"' do
+          expect(pc.status).to eq Status.unexpected_version
+          po_handler.update_version
+          expect(pc.reload.status).to eq Status.default_status
+        end
+        it "logs at info level" do
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_po_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_pc_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_po_db_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_pc_db_msg)
+          allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_status_msg_regex)
+          po_handler.update_version
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_gt_po_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_gt_pc_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_po_db_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_pc_db_msg)
+          expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_status_msg_regex)
+        end
+
+        context 'returns' do
+          let!(:results) { po_handler.update_version }
+
+          # results = [result1, result2]
+          # result1 = {response_code: msg}
+          # result2 = {response_code: msg}
+          it '5 results' do
+            expect(results).to be_an_instance_of Array
+            expect(results.size).to eq 5
+          end
+          it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
+            code = PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT
+            expect(results).to include(a_hash_including(code => version_gt_pc_msg))
+            expect(results).to include(a_hash_including(code => version_gt_po_msg))
+          end
+          it "UPDATED_DB_OBJECT results" do
+            code = PreservedObjectHandler::UPDATED_DB_OBJECT
+            expect(results).to include(a_hash_including(code => updated_pc_db_msg))
+            expect(results).to include(a_hash_including(code => updated_po_db_msg))
+          end
+          it 'PC_STATUS_CHANGED result' do
+            expect(results).to include(a_hash_including(PreservedObjectHandler::PC_STATUS_CHANGED => updated_status_msg_regex))
+          end
+        end
+      end
+
+      # context "incoming and db versions match" do
+      #   let(:po_handler) { described_class.new(druid, 2, 1, storage_dir) }
+      #   let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, 1, #{storage_dir})" }
+      #   let(:version_matches_po_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedObject db version" }
+      #   let(:version_matches_pc_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservationCopy db version" }
+      #   let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
+      #   let(:updated_pc_db_timestamp_msg) { "#{exp_msg_prefix} PreservationCopy updated db timestamp only" }
+      #
+      #   it "entry version stays the same" do
+      #     expect(po.current_version).to eq 2
+      #     expect(pc.current_version).to eq 2
+      #     po_handler.update
+      #     expect(po.reload.current_version).to eq 2
+      #     expect(pc.reload.current_version).to eq 2
+      #   end
+      #   it "entry size stays the same" do
+      #     expect(po.size).to eq 1
+      #     po_handler.update
+      #     expect(po.reload.size).to eq 1
+      #   end
+      #   it "logs at info level" do
+      #     allow(Rails.logger).to receive(:log).with(Logger::INFO, version_matches_po_msg)
+      #     allow(Rails.logger).to receive(:log).with(Logger::INFO, version_matches_pc_msg)
+      #     allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+      #     allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+      #     po_handler.update
+      #     expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_matches_po_msg)
+      #     expect(Rails.logger).to have_received(:log).with(Logger::INFO, version_matches_pc_msg)
+      #     expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+      #     expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+      #
+      #   end
+      #   context 'returns' do
+      #     let!(:results) { po_handler.update }
+      #
+      #     # results = [result1, result2]
+      #     # result1 = {response_code: msg}
+      #     # result2 = {response_code: msg}
+      #     it '4 results' do
+      #       expect(results).to be_an_instance_of Array
+      #       expect(results.size).to eq 4
+      #     end
+      #     it 'PreservedObject VERSION_MATCHES result' do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::VERSION_MATCHES] }.first.values.first
+      #       expect(result_msg).to match(Regexp.escape(version_matches_po_msg))
+      #     end
+      #     it 'PreservationCopy VERSION_MATCHES result' do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::VERSION_MATCHES] }.second.values.first
+      #       expect(result_msg).to match(Regexp.escape(version_matches_pc_msg))
+      #     end
+      #     it "PreservedObject UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.first.values.first
+      #       expect(result_msg).to match(Regexp.escape(updated_po_db_timestamp_msg))
+      #     end
+      #     it "PreservationCopy UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.second.values.first
+      #       expect(result_msg).to match(Regexp.escape(updated_pc_db_timestamp_msg))
+      #     end
+      #   end
+      # end
+
+      # context 'incoming version older than db version' do
+      #   let(:po_handler) { described_class.new(druid, 1, 666, storage_dir) }
+      #   let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, 666, #{storage_dir})" }
+      #   let(:version_less_than_po_msg) { "#{exp_msg_prefix} incoming version (1) less than PreservedObject db version; ERROR!" }
+      #   let(:version_less_than_pc_msg) { "#{exp_msg_prefix} incoming version (1) less than PreservationCopy db version; ERROR!" }
+      #   let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
+      #   let(:updated_pc_db_timestamp_msg) { "#{exp_msg_prefix} PreservationCopy updated db timestamp only" }
+      #
+      #   it "entry version stays the same" do
+      #     expect(po.current_version).to eq 2
+      #     expect(pc.current_version).to eq 2
+      #     po_handler.update
+      #     expect(po.reload.current_version).to eq 2
+      #     expect(pc.reload.current_version).to eq 2
+      #   end
+      #   it "entry size stays the same" do
+      #     expect(po.size).to eq 1
+      #     po_handler.update
+      #     expect(po.reload.size).to eq 1
+      #   end
+      #   it "logs at error level" do
+      #     allow(Rails.logger).to receive(:log).with(Logger::ERROR, version_less_than_po_msg)
+      #     allow(Rails.logger).to receive(:log).with(Logger::ERROR, version_less_than_pc_msg)
+      #     allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+      #     allow(Rails.logger).to receive(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+      #
+      #     po_handler.update
+      #     expect(Rails.logger).to have_received(:log).with(Logger::ERROR, version_less_than_po_msg)
+      #     expect(Rails.logger).to have_received(:log).with(Logger::ERROR, version_less_than_pc_msg)
+      #     expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_po_db_timestamp_msg)
+      #     expect(Rails.logger).to have_received(:log).with(Logger::INFO, updated_pc_db_timestamp_msg)
+      #
+      #   end
+      #   context 'returns' do
+      #     let!(:results) { po_handler.update }
+      #
+      #     # results = [result1, result2]
+      #     # result1 = {response_code: msg}
+      #     # result2 = {response_code: msg}
+      #     it '4 results' do
+      #       expect(results).to be_an_instance_of Array
+      #       expect(results.size).to eq 4
+      #     end
+      #     it 'PreservedObject ARG_VERSION_LESS_THAN_DB_OBJECT result' do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT] }.first.values.first
+      #       expect(result_msg).to match(Regexp.escape(version_less_than_po_msg))
+      #     end
+      #     it 'PreservationCopy ARG_VERSION_LESS_THAN_DB_OBJECT result' do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT] }.second.values.first
+      #       expect(result_msg).to match(Regexp.escape(version_less_than_pc_msg))
+      #     end
+      #     # FIXME: do we want to update timestamp if we found an error (ARG_VERSION_LESS_THAN_DB_OBJECT)
+      #     it "PreservedObject UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.first.values.first
+      #       expect(result_msg).to match(Regexp.escape(updated_po_db_timestamp_msg))
+      #     end
+      #     it "PreservationCopy UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
+      #       result_msg = results.select { |r| r[PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY] }.second.values.first
+      #       expect(result_msg).to match(Regexp.escape(updated_pc_db_timestamp_msg))
+      #     end
+      #   end
+      # end
+
+      context 'db update error' do
+        context 'PreservationCopy' do
+          context 'ActiveRecordError' do
+            let(:db_update_failed_prefix) { "#{exp_msg_prefix} db update failed" }
+            let(:results) do
+              allow(Rails.logger).to receive(:log)
+              # FIXME: couldn't figure out how to put next line into its own test
+              expect(Rails.logger).to receive(:log).with(Logger::ERROR, /#{Regexp.escape(db_update_failed_prefix)}/)
+
+              po = instance_double('PreservedObject')
+              allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+              pc = instance_double('PreservationCopy')
+              allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+              allow(pc).to receive(:current_version).and_return(1)
+              allow(pc).to receive(:current_version=)
+              allow(pc).to receive(:changed?).and_return(true)
+              allow(pc).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              status = instance_double('Status')
+              allow(status).to receive(:status_text)
+              allow(pc).to receive(:status).and_return(status)
+              allow(pc).to receive(:status=)
+              po_handler.update_version
+            end
+
+            it 'DB_UPDATE_FAILED error' do
+              expect(results).to include(a_hash_including(PreservedObjectHandler::DB_UPDATE_FAILED))
+            end
+            context 'error message' do
+              let(:result_msg) { results.select { |r| r[PreservedObjectHandler::DB_UPDATE_FAILED] }.first.values.first }
+
+              it 'prefix' do
+                expect(result_msg).to match(Regexp.escape(db_update_failed_prefix))
+              end
+              it 'specific exception raised' do
+                expect(result_msg).to match(Regexp.escape('ActiveRecord::ActiveRecordError'))
+              end
+              it "exception's message" do
+                expect(result_msg).to match(Regexp.escape('foo'))
+              end
+            end
+          end
+        end
+        context 'PreservedObject' do
+          context 'ActiveRecordError' do
+            let(:db_update_failed_prefix) { "#{exp_msg_prefix} db update failed" }
+            let(:results) do
+              allow(Rails.logger).to receive(:log)
+              # FIXME: couldn't figure out how to put next line into its own test
+              expect(Rails.logger).to receive(:log).with(Logger::ERROR, /#{Regexp.escape(db_update_failed_prefix)}/)
+
+              po = instance_double('PreservedObject')
+              allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+              allow(po).to receive(:current_version).and_return(1)
+              allow(po).to receive(:current_version=).with(incoming_version)
+              allow(po).to receive(:size=).with(incoming_size)
+              allow(po).to receive(:changed?).and_return(true)
+              allow(po).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              pc = instance_double('PreservationCopy')
+              allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+              allow(pc).to receive(:current_version).and_return(5)
+              allow(pc).to receive(:current_version=).with(incoming_version)
+              allow(pc).to receive(:changed?).and_return(true)
+              allow(pc).to receive(:save)
+              status = instance_double('Status')
+              allow(status).to receive(:status_text)
+              allow(pc).to receive(:status).and_return(status)
+              allow(pc).to receive(:status=)
+              po_handler.update_version
+            end
+
+            it 'DB_UPDATE_FAILED error' do
+              expect(results).to include(a_hash_including(PreservedObjectHandler::DB_UPDATE_FAILED))
+            end
+            context 'error message' do
+              let(:result_msg) { results.select { |r| r[PreservedObjectHandler::DB_UPDATE_FAILED] }.first.values.first }
+
+              it 'prefix' do
+                expect(result_msg).to match(Regexp.escape(db_update_failed_prefix))
+              end
+              it 'specific exception raised' do
+                expect(result_msg).to match(Regexp.escape('ActiveRecord::ActiveRecordError'))
+              end
+              it "exception's message" do
+                expect(result_msg).to match(Regexp.escape('foo'))
+              end
+            end
+          end
+
+        end
+      end
+
+      # it 'calls PreservedObject.save and PreservationCopy.save if the existing record is altered' do
+      #   po = instance_double(PreservedObject)
+      #   pc = instance_double(PreservationCopy)
+      #   allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+      #   allow(po).to receive(:current_version).and_return(1)
+      #   allow(po).to receive(:current_version=).with(incoming_version)
+      #   allow(po).to receive(:size=).with(incoming_size)
+      #   allow(po).to receive(:changed?).and_return(true)
+      #   allow(po).to receive(:save)
+      #   allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+      #   allow(pc).to receive(:current_version).and_return(1)
+      #   allow(pc).to receive(:current_version=).with(incoming_version)
+      #   allow(pc).to receive(:endpoint).with(ep)
+      #   allow(pc).to receive(:changed?).and_return(true)
+      #   allow(pc).to receive(:save)
+      #   po_handler.update_version
+      #   expect(po).to have_received(:save)
+      #   expect(pc).to have_received(:save)
+      # end
+
+      # it 'calls PreservedObject.touch and PreservationCopy.touch if the existing record is NOT altered' do
+      #   po_handler = described_class.new(druid, 1, 1, storage_dir)
+      #   po = instance_double(PreservedObject)
+      #   pc = instance_double(PreservationCopy)
+      #   allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+      #   allow(po).to receive(:current_version).and_return(1)
+      #   allow(po).to receive(:changed?).and_return(false)
+      #   allow(po).to receive(:touch)
+      #   allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+      #   allow(pc).to receive(:current_version).and_return(1)
+      #   allow(pc).to receive(:endpoint).with(ep)
+      #   allow(pc).to receive(:changed?).and_return(false)
+      #   allow(pc).to receive(:touch)
+      #   po_handler.update_version
+      #   expect(po).to have_received(:touch)
+      #   expect(pc).to have_received(:touch)
+      # end
+
+      it 'logs a debug message' do
+        msg = "update_version #{druid} called and object exists"
+        allow(Rails.logger).to receive(:debug)
+        po_handler.update_version
+        expect(Rails.logger).to have_received(:debug).with(msg)
       end
     end
   end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -602,43 +602,46 @@ RSpec.describe PreservedObjectHandler do
         end
       end
 
-      # it 'calls PreservedObject.save and PreservationCopy.save if the existing record is altered' do
-      #   po = instance_double(PreservedObject)
-      #   pc = instance_double(PreservationCopy)
-      #   allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-      #   allow(po).to receive(:current_version).and_return(1)
-      #   allow(po).to receive(:current_version=).with(incoming_version)
-      #   allow(po).to receive(:size=).with(incoming_size)
-      #   allow(po).to receive(:changed?).and_return(true)
-      #   allow(po).to receive(:save)
-      #   allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-      #   allow(pc).to receive(:current_version).and_return(1)
-      #   allow(pc).to receive(:current_version=).with(incoming_version)
-      #   allow(pc).to receive(:endpoint).with(ep)
-      #   allow(pc).to receive(:changed?).and_return(true)
-      #   allow(pc).to receive(:save)
-      #   po_handler.update_version
-      #   expect(po).to have_received(:save)
-      #   expect(pc).to have_received(:save)
-      # end
+      it 'calls PreservedObject.save and PreservationCopy.save if the existing record is altered' do
+        po = instance_double(PreservedObject)
+        pc = instance_double(PreservationCopy)
+        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+        allow(po).to receive(:current_version).and_return(1)
+        allow(po).to receive(:current_version=).with(incoming_version)
+        allow(po).to receive(:size=).with(incoming_size)
+        allow(po).to receive(:changed?).and_return(true)
+        allow(po).to receive(:save)
+        allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:current_version).and_return(1)
+        allow(pc).to receive(:current_version=).with(incoming_version)
+        allow(pc).to receive(:endpoint).with(ep)
+        allow(pc).to receive(:changed?).and_return(true)
+        allow(pc).to receive(:status).and_return(instance_double(Status, status_text: 'ok'))
+        allow(pc).to receive(:status=)
+        allow(pc).to receive(:save)
+        po_handler.update_version
+        expect(po).to have_received(:save)
+        expect(pc).to have_received(:save)
+      end
 
-      # it 'calls PreservedObject.touch and PreservationCopy.touch if the existing record is NOT altered' do
-      #   po_handler = described_class.new(druid, 1, 1, storage_dir)
-      #   po = instance_double(PreservedObject)
-      #   pc = instance_double(PreservationCopy)
-      #   allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-      #   allow(po).to receive(:current_version).and_return(1)
-      #   allow(po).to receive(:changed?).and_return(false)
-      #   allow(po).to receive(:touch)
-      #   allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-      #   allow(pc).to receive(:current_version).and_return(1)
-      #   allow(pc).to receive(:endpoint).with(ep)
-      #   allow(pc).to receive(:changed?).and_return(false)
-      #   allow(pc).to receive(:touch)
-      #   po_handler.update_version
-      #   expect(po).to have_received(:touch)
-      #   expect(pc).to have_received(:touch)
-      # end
+      it 'calls PreservedObject.touch and PreservationCopy.touch if the existing record is NOT altered' do
+        skip('need to determine if we want to update timestamps in this situation')
+        po_handler = described_class.new(druid, 1, 1, storage_dir)
+        po = instance_double(PreservedObject)
+        pc = instance_double(PreservationCopy)
+        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+        allow(po).to receive(:current_version).and_return(1)
+        allow(po).to receive(:changed?).and_return(false)
+        allow(po).to receive(:touch)
+        allow(PreservationCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:current_version).and_return(1)
+        allow(pc).to receive(:endpoint).with(ep)
+        allow(pc).to receive(:changed?).and_return(false)
+        allow(pc).to receive(:touch)
+        po_handler.update_version
+        expect(po).to have_received(:touch)
+        expect(pc).to have_received(:touch)
+      end
 
       it 'logs a debug message' do
         msg = "update_version #{druid} called and druid in Catalog"

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe PreservedObjectHandler do
     it_behaves_like 'attributes validated', :update_version
 
     context 'PreservedObject does not exist' do
-      let!(:exp_msg) { "#{exp_msg_prefix} PreservedObject db object does not exist" }
+      let(:exp_msg) { "#{exp_msg_prefix} PreservedObject db object does not exist" }
       let(:db_update_failed_prefix) { "#{exp_msg_prefix} db update failed" }
       let(:results) do
         allow(Rails.logger).to receive(:log)
@@ -256,7 +256,7 @@ RSpec.describe PreservedObjectHandler do
       before do
         PreservedObject.create!(druid: druid, current_version: 2, size: 1, preservation_policy: default_prez_policy)
       end
-      let!(:exp_msg) { "#{exp_msg_prefix} PreservationCopy db object does not exist" }
+      let(:exp_msg) { "#{exp_msg_prefix} PreservationCopy db object does not exist" }
       let(:db_update_failed_prefix) { "#{exp_msg_prefix} db update failed" }
       let(:results) do
         allow(Rails.logger).to receive(:log)


### PR DESCRIPTION
this splits out the version updating for ingest robots and such from the version confirmation for audit checks and such.

closes #181
closes #197
closes #211
closes #218
closes #221

much pairing and branch wrangling with @tingulfsen and @ndushay.